### PR TITLE
Bug Fix: SemanticsVisitor cannot be cached 

### DIFF
--- a/PCGen-Formula/code/src/java/pcgen/base/formula/inst/SimpleFormulaManager.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/inst/SimpleFormulaManager.java
@@ -45,13 +45,6 @@ import pcgen.base.util.FormatManager;
  */
 public class SimpleFormulaManager implements FormulaManager
 {
-
-	/**
-	 * The SemanticsVisitor for this FormulaManager. Can return the
-	 * FormulaSemantics for a parsed tree. Lazily Instantiated.
-	 */
-	private SemanticsVisitor semanticsVisitor;
-
 	/**
 	 * The FunctionLibrary used to store valid functions in this FormulaManager.
 	 */
@@ -204,10 +197,8 @@ public class SimpleFormulaManager implements FormulaManager
 			throw new IllegalArgumentException(
 				"Cannot determine validity with null FormatManager");
 		}
-		if (semanticsVisitor == null)
-		{
-			semanticsVisitor = new SemanticsVisitor(this, legalScope);
-		}
+		SemanticsVisitor semanticsVisitor =
+				new SemanticsVisitor(this, legalScope);
 		FormulaSemantics semantics =
 				FormulaSemanticsUtilities.getInitializedSemantics();
 		semanticsVisitor.visit(root, semantics);


### PR DESCRIPTION
because the scope (stored by the visitor) is passed into isValid and thus may change between calls to
isValid
