### PR TITLE
Change VarScoped to use getKeyName() for the unique name - helps out

### DIFF
--- a/PCGen-Formula/code/src/java/pcgen/base/formula/base/VarScoped.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/base/VarScoped.java
@@ -30,7 +30,7 @@ public interface VarScoped
 	 * 
 	 * @return The name of this VarScoped object
 	 */
-	public String getName();
+	public String getKeyName();
 
 	/**
 	 * Returns the Local Scope name for this VarScoped object.

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/inst/ScopeInstanceFactory.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/inst/ScopeInstanceFactory.java
@@ -169,7 +169,7 @@ public class ScopeInstanceFactory
 				throw new IllegalArgumentException(
 					"Requested ScopeInstance for "
 						+ original.getClass().getName() + " "
-						+ original.getName() + " but in an uncompatible "
+						+ original.getKeyName() + " but in an uncompatible "
 						+ "LegalScope: " + instScope.getName());
 			}
 		}


### PR DESCRIPTION
with PCGen integration
