### PR TITLE
Simplify Modifier Interface to have one priority

### DIFF
--- a/PCGen-Formula/code/src/java/pcgen/base/calculation/ArrayComponentModifier.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/calculation/ArrayComponentModifier.java
@@ -131,18 +131,9 @@ public class ArrayComponentModifier<T> implements Modifier<T[]>
 	 * {@inheritDoc}
 	 */
 	@Override
-	public int getInherentPriority()
+	public long getPriority()
 	{
-		return modifier.getInherentPriority();
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public int getUserPriority()
-	{
-		return modifier.getUserPriority();
+		return modifier.getPriority();
 	}
 
 	/**

--- a/PCGen-Formula/code/src/java/pcgen/base/calculation/CalculationModifier.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/calculation/CalculationModifier.java
@@ -36,7 +36,7 @@ public final class CalculationModifier<T> implements Modifier<T>
 	/**
 	 * The user priority for this CalculationModifier.
 	 */
-	private final int userPriority;
+	private final long userPriority;
 
 	/**
 	 * The NEPCalculation to be performed by this CalculationModifier.
@@ -72,9 +72,9 @@ public final class CalculationModifier<T> implements Modifier<T>
 	 * {@inheritDoc}
 	 */
 	@Override
-	public int getUserPriority()
+	public long getPriority()
 	{
-		return userPriority;
+		return (userPriority << 32) + toDo.getInherentPriority();
 	}
 
 	/**
@@ -84,15 +84,6 @@ public final class CalculationModifier<T> implements Modifier<T>
 	public T process(T input, ScopeInformation scopeInfo, Object source)
 	{
 		return toDo.process(input, scopeInfo, source);
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public int getInherentPriority()
-	{
-		return toDo.getInherentPriority();
 	}
 
 	/**
@@ -137,7 +128,7 @@ public final class CalculationModifier<T> implements Modifier<T>
 	@Override
 	public int hashCode()
 	{
-		return userPriority ^ toDo.hashCode();
+		return ((int) userPriority) ^ toDo.hashCode();
 	}
 
 	/**

--- a/PCGen-Formula/code/src/java/pcgen/base/calculation/Modifier.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/calculation/Modifier.java
@@ -17,6 +17,9 @@
  */
 package pcgen.base.calculation;
 
+import pcgen.base.formula.base.DependencyManager;
+import pcgen.base.formula.inst.ScopeInformation;
+
 /**
  * A Modifier is designed to change an input (of a given format) to another
  * object of that format.
@@ -30,19 +33,81 @@ package pcgen.base.calculation;
  * @param <T>
  *            The format that this Modifier acts upon
  */
-public interface Modifier<T> extends NEPCalculation<T>
+public interface Modifier<T>
 {
 	/**
-	 * Returns the user priority of this Modifier. This is considered by a
-	 * Solver when there are multiple Modifiers to be applied.
+	 * "Processes" (or runs) the Modifier in order to determine the appropriate
+	 * result of the Modifier.
+	 * 
+	 * There is no requirement that a Modifier take into account the input value
+	 * (it can be a "set").
+	 * 
+	 * The Modifier should treat the input as an Immutable object (it does not
+	 * gain ownership of that parameter).
+	 * 
+	 * @param input
+	 *            The input value used (if necessary) to determine the
+	 *            appropriate result of this Modifier
+	 * @param scopeInfo
+	 *            The ScopeInformation that is used (if necessary) to process a
+	 *            Formula that is contained by this Modifier
+	 * @param source
+	 *            The "source" of the process being performed, so it can be
+	 *            referred back to if necessary
+	 * @return The resulting value of the Modifier
+	 */
+	public T process(T input, ScopeInformation scopeInfo, Object source);
+
+	/**
+	 * Loads the dependencies for the Modifier into the given DependencyManager.
+	 * 
+	 * The DependencyManager may not be altered if there are no dependencies for
+	 * this Modifier.
+	 * 
+	 * @param fdm
+	 *            The DependencyManager to be notified of dependencies for this
+	 *            Modifier
+	 */
+	public void getDependencies(DependencyManager fdm);
+
+	/**
+	 * Returns the priority of this Modifier. This is defined by the developer,
+	 * and is intended to set the order of operations for a Modifier when
+	 * processed by a Solver.
 	 * 
 	 * A lower priority is acted upon first.
 	 * 
-	 * The user priority is considered before the inherent priority of the
-	 * Modifier.
+	 * For example, a calculation that performs Multiplication would want to
+	 * have a lower priority (acting first) than a calculation that performs
+	 * addition (since multiplication before addition is the natural order of
+	 * operations in mathematics)
 	 * 
-	 * @return The user priority of this Modifier.
+	 * @return The priority of this calculation
 	 */
-	public int getUserPriority();
+	public long getPriority();
 
+	/**
+	 * Returns the Format (Class) of object upon which this Modifier can
+	 * operate. May be a parent class if the Modifier can act upon various
+	 * related classes such as java.lang.Number.
+	 * 
+	 * @return The Class of object upon which this Modifier can operate
+	 */
+	public Class<T> getVariableFormat();
+
+	/**
+	 * Returns a String identifying the Modifier. May be "ADD" for a Modifier
+	 * that performs Addition.
+	 * 
+	 * @return A String identifying the behavior of the Modifier
+	 */
+	public String getIdentification();
+
+	/**
+	 * Returns a String identifying the formula used for Modifier. May be "3"
+	 * for a Modifier that performs Addition of 3.
+	 * 
+	 * @return A String identifying the formula used for Modifier
+	 */
+	public String getInstructions();
 }

--- a/PCGen-Formula/code/src/java/pcgen/base/solver/Solver.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/solver/Solver.java
@@ -150,7 +150,7 @@ public class Solver<T>
 					+ varFormat.getCanonicalName() + " but got: "
 					+ modifier.getVariableFormat().getCanonicalName());
 		}
-		modifierList.addToListFor(Long.valueOf(getPriority(modifier)),
+		modifierList.addToListFor(Long.valueOf(modifier.getPriority()),
 			new ModInfo<>(modifier, source));
 		sourceList.addToListFor(source, modifier);
 	}
@@ -181,7 +181,7 @@ public class Solver<T>
 			throw new IllegalArgumentException(
 				"Cannot remove Modifier with null source");
 		}
-		modifierList.removeFromListFor(Long.valueOf(getPriority(modifier)),
+		modifierList.removeFromListFor(Long.valueOf(modifier.getPriority()),
 			new ModInfo<>(modifier, source));
 		sourceList.removeFromListFor(source, modifier);
 	}
@@ -211,42 +211,9 @@ public class Solver<T>
 				@SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
 				ModInfo<T> modInfo = new ModInfo<>(modifier, source);
 				modifierList.removeFromListFor(
-					Long.valueOf(getPriority(modifier)), modInfo);
+					Long.valueOf(modifier.getPriority()), modInfo);
 			}
 		}
-	}
-
-	/**
-	 * Gets the full priority of the Modifier. This processes the rules
-	 * described on the Modifier interface, in that the user priority takes
-	 * precedence, and then the inherent priority is used. Builds these into a
-	 * single long value, so that a single sort can be used to process both
-	 * priority values.
-	 * 
-	 * @param modifier
-	 *            The Modifier for which the full priority should be returned
-	 * @return A long representing the combination of the user priority and
-	 *         inherent priority
-	 */
-	private long getPriority(Modifier<T> modifier)
-	{
-		int inherentPriority = modifier.getInherentPriority();
-		if (inherentPriority < 0)
-		{
-			/*
-			 * Required to reject this or the ordering will not be correct due
-			 * to bitwise creation of overall priority. This "contract" is
-			 * defined on the Modifier interface.
-			 */
-			throw new IllegalArgumentException(
-				"Cannot add Modifier with InherentPriority < 0");
-		}
-		/*
-		 * TODO Some limit on user priority; (positive?)
-		 */
-		//Must be a long or the shift below will result in 0 effective user priority
-		long userPriority = modifier.getUserPriority();
-		return (userPriority << 32) + inherentPriority;
 	}
 
 	/**

--- a/PCGen-Formula/code/src/test/pcgen/base/calculation/ArrayComponentModifierTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/calculation/ArrayComponentModifierTest.java
@@ -61,15 +61,7 @@ public class ArrayComponentModifierTest extends TestCase
 	{
 		CalculationModifier cm = new CalculationModifier(calc, 5);
 		ArrayComponentModifier acm = new ArrayComponentModifier(5, cm);
-		assertEquals(5, acm.getUserPriority());
-	}
-
-	@Test
-	public void testGetInherentPriority()
-	{
-		CalculationModifier cm = new CalculationModifier(calc, 5);
-		ArrayComponentModifier acm = new ArrayComponentModifier(5, cm);
-		assertEquals(6, acm.getInherentPriority());
+		assertEquals((5l << 32) + 6, acm.getPriority());
 	}
 
 	@Test

--- a/PCGen-Formula/code/src/test/pcgen/base/calculation/CalculationModifierTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/calculation/CalculationModifierTest.java
@@ -49,14 +49,7 @@ public class CalculationModifierTest extends TestCase
 	public void testGetUserPriority()
 	{
 		CalculationModifier cm = new CalculationModifier(calc, 5);
-		assertEquals(5, cm.getUserPriority());
-	}
-
-	@Test
-	public void testGetInherentPriority()
-	{
-		CalculationModifier cm = new CalculationModifier(calc, 5);
-		assertEquals(6, cm.getInherentPriority());
+		assertEquals((5l << 32) + 6, cm.getPriority());
 	}
 
 	@Test

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/SolverTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/SolverTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 
 import pcgen.base.calculation.ArrayComponentModifier;
 import pcgen.base.calculation.Modifier;
-import pcgen.base.formula.base.DependencyManager;
 import pcgen.base.formula.inst.ScopeInformation;
 import pcgen.base.formula.inst.SimpleLegalScope;
 import pcgen.base.solver.testsupport.AbstractModifier;
@@ -116,60 +115,6 @@ public class SolverTest extends TestCase
 		{
 			//ok
 		}
-		try
-		{
-			//have to be bad about generics to even get this to be set up to fail
-			Modifier m = new Modifier(){
-
-				@Override
-				public Object process(Object input, ScopeInformation scopeInfo, Object owner)
-				{
-					return 3;
-				}
-
-				@Override
-				public void getDependencies(DependencyManager fdm)
-				{
-				}
-
-				@Override
-				public String getInstructions()
-				{
-					return "3";
-				}
-
-				@Override
-				public String getIdentification()
-				{
-					return "SET";
-				}
-
-				@Override
-				public Class getVariableFormat()
-				{
-					return Number.class;
-				}
-
-				@Override
-				public int getInherentPriority()
-				{
-					//bad (intentional)
-					return -1;
-				}
-
-				@Override
-				public int getUserPriority()
-				{
-					return 0;
-				}};
-			solver.addModifier(m, new Object());
-			fail("wrong type must be rejected");
-		}
-		catch (IllegalArgumentException e)
-		{
-			//ok
-		}
-
 	}
 
 	@Test

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/testsupport/AbstractModifier.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/testsupport/AbstractModifier.java
@@ -93,15 +93,10 @@ public abstract class AbstractModifier<T> implements Modifier<T>
 	}
 
 	@Override
-	public int getInherentPriority()
+	public long getPriority()
 	{
-		return inherent;
-	}
-
-	@Override
-	public int getUserPriority()
-	{
-		return priority;
+		long l = priority;
+		return (l << 32) + inherent;
 	}
 
 	@Override


### PR DESCRIPTION
This simplifies how the Solver/SolverManager interact with Modifiers, to give them only one priority value, rather than two.  This gives more flexibility for how (and when) Modifier priority is calculated
