### PR TITLE
Remove unreachable code

### DIFF
--- a/PCGen-Formula/code/src/java/pcgen/base/formula/library/GenericFunction.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/library/GenericFunction.java
@@ -124,16 +124,6 @@ public class GenericFunction implements Function
 		semantics.pop(FormulaSemantics.FMANAGER);
 		ArgumentDependencyManager myArgs =
 				semantics.pop(ArgumentDependencyManager.KEY);
-		if (myArgs == null)
-		{
-			if (args.length != 0)
-			{
-				semantics.setInvalid("Function " + getFunctionName()
-					+ " received incorrect # of arguments, expected: 0 got "
-					+ args.length + " " + Arrays.asList(args));
-			}
-			return null;
-		}
 		int maxArg = myArgs.getMaximumArgument() + 1;
 		if (maxArg != args.length)
 		{


### PR DESCRIPTION
Since semantics now uses push/pull, the ArgumentDependencyManager cannot
be null, so the block cannot be reasonably reached, and the later arg
length check will catch any mismatches
