### PR TITLE
Rebuild ScopeInstanceFactory

### DIFF
--- a/PCGen-Formula/code/src/java/pcgen/base/solver/IndividualSetup.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/solver/IndividualSetup.java
@@ -18,7 +18,6 @@
 package pcgen.base.solver;
 
 import pcgen.base.formula.base.FormulaManager;
-import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.LegalScopeLibrary;
 import pcgen.base.formula.base.ScopeInstance;
 import pcgen.base.formula.base.WriteableVariableStore;
@@ -42,11 +41,6 @@ public class IndividualSetup
 	 * The FormulaManager for this IndividualSetup.
 	 */
 	private final FormulaManager formulaManager;
-
-	/**
-	 * The "Global" LegalScope for this IndividualSetup.
-	 */
-	private final LegalScope globalScope;
 
 	/**
 	 * The "Global" ScopeInstance for this IndividualSetup.
@@ -80,13 +74,12 @@ public class IndividualSetup
 	public IndividualSetup(SplitFormulaSetup parent, String globalName)
 	{
 		LegalScopeLibrary scopeLibrary = parent.getLegalScopeLibrary();
-		globalScope = scopeLibrary.getScope(globalName);
 		instanceFactory = new ScopeInstanceFactory(scopeLibrary);
 		formulaManager =
 				new SimpleFormulaManager(parent.getFunctionLibrary(),
 					parent.getOperatorLibrary(), parent.getVariableLibrary(),
 					getVariableStore());
-		globalScopeInst = instanceFactory.getInstance(null, globalScope);
+		globalScopeInst = instanceFactory.getInstance(null, globalName, null);
 	}
 
 	/**
@@ -107,16 +100,6 @@ public class IndividualSetup
 	public FormulaManager getFormulaManager()
 	{
 		return formulaManager;
-	}
-
-	/**
-	 * Return the "Global" LegalScope for this IndividualSetup.
-	 * 
-	 * @return the "Global" LegalScope for this IndividualSetup
-	 */
-	public LegalScope getGlobalScope()
-	{
-		return globalScope;
 	}
 
 	/**

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/base/VariableIDTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/base/VariableIDTest.java
@@ -17,19 +17,29 @@
  */
 package pcgen.base.formula.base;
 
-import junit.framework.TestCase;
-
 import org.junit.Test;
 
+import junit.framework.TestCase;
 import pcgen.base.format.NumberManager;
 import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.formula.inst.ScopeInstanceFactory;
 import pcgen.base.formula.inst.SimpleLegalScope;
-import pcgen.base.formula.inst.SimpleScopeInstance;
 
 public class VariableIDTest extends TestCase
 {
 
 	NumberManager numberManager = FormatUtilities.NUMBER_MANAGER;
+	private LegalScopeLibrary library;
+	private ScopeInstanceFactory instanceFactory;
+
+	@Override
+	protected void setUp() throws Exception
+	{
+		super.setUp();
+		library = new LegalScopeLibrary();
+		library.registerScope(new SimpleLegalScope(null, "Global"));
+		instanceFactory = new ScopeInstanceFactory(library);
+	}
 
 	@Test
 	public void testDoubleConstructor()
@@ -47,8 +57,7 @@ public class VariableIDTest extends TestCase
 		{
 			//ok, too			
 		}
-		LegalScope varScope = new SimpleLegalScope(null, "Global");
-		ScopeInstance globalInst = new SimpleScopeInstance(null, varScope);
+		ScopeInstance globalInst = instanceFactory.getInstance(null, "Global", null);
 		try
 		{
 			new VariableID(globalInst, numberManager, null);
@@ -118,8 +127,7 @@ public class VariableIDTest extends TestCase
 
 	public void testGlobal()
 	{
-		LegalScope varScope = new SimpleLegalScope(null, "Global");
-		ScopeInstance globalInst = new SimpleScopeInstance(null, varScope);
+		ScopeInstance globalInst = instanceFactory.getInstance(null, "Global", null);
 		VariableID vid = new VariableID(globalInst, numberManager, "test");
 		assertEquals("test", vid.getName());
 		assertEquals(globalInst, vid.getScope());
@@ -128,9 +136,9 @@ public class VariableIDTest extends TestCase
 
 	public void testEquals()
 	{
-		LegalScope varScope = new SimpleLegalScope(null, "Global");
-		ScopeInstance globalInst = new SimpleScopeInstance(null, varScope);
-		ScopeInstance globalInst2 = new SimpleScopeInstance(null, varScope);
+		ScopeInstance globalInst = instanceFactory.getInstance(null, "Global", null);
+		library.registerScope(new SimpleLegalScope(null, "Global2"));
+		ScopeInstance globalInst2 = instanceFactory.getInstance(null, "Global2", null);
 		VariableID vid1 = new VariableID(globalInst, numberManager, "test");
 		VariableID vid2 = new VariableID(globalInst, numberManager, "test");
 		VariableID vid3 = new VariableID(globalInst, numberManager, "test2");
@@ -146,9 +154,9 @@ public class VariableIDTest extends TestCase
 
 	public void testHashCode()
 	{
-		LegalScope varScope = new SimpleLegalScope(null, "Global");
-		ScopeInstance globalInst = new SimpleScopeInstance(null, varScope);
-		ScopeInstance globalInst2 = new SimpleScopeInstance(null, varScope);
+		ScopeInstance globalInst = instanceFactory.getInstance(null, "Global", null);
+		library.registerScope(new SimpleLegalScope(null, "Global2"));
+		ScopeInstance globalInst2 = instanceFactory.getInstance(null, "Global2", null);
 		VariableID vid1 = new VariableID(globalInst, numberManager, "test");
 		VariableID vid2 = new VariableID(globalInst, numberManager, "test");
 		VariableID vid3 = new VariableID(globalInst, numberManager, "bummer");

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/base/VariableLibraryTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/base/VariableLibraryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 (C) Tom Parker <thpr@users.sourceforge.net>
+pyright 2014 (C) Tom Parker <thpr@users.sourceforge.net>
  * 
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -19,20 +19,20 @@ package pcgen.base.formula.base;
 
 import java.util.Set;
 
-import junit.framework.TestCase;
-
 import org.junit.Test;
 
+import junit.framework.TestCase;
 import pcgen.base.format.BooleanManager;
 import pcgen.base.format.NumberManager;
 import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.formula.inst.ScopeInstanceFactory;
 import pcgen.base.formula.inst.SimpleLegalScope;
-import pcgen.base.formula.inst.SimpleScopeInstance;
 
 public class VariableLibraryTest extends TestCase
 {
 
 	private NumberManager numberManager = FormatUtilities.NUMBER_MANAGER;
+	private ScopeInstanceFactory instanceFactory;
 	private LegalScopeLibrary varScopeLib;
 	private VariableLibrary varLib;
 
@@ -41,6 +41,7 @@ public class VariableLibraryTest extends TestCase
 	{
 		super.setUp();
 		varScopeLib = new LegalScopeLibrary();
+		instanceFactory = new ScopeInstanceFactory(varScopeLib);
 		varLib = new VariableLibrary(varScopeLib);
 	}
 
@@ -326,10 +327,14 @@ public class VariableLibraryTest extends TestCase
 	public void testGetVIDFail()
 	{
 		LegalScope globalScope = new SimpleLegalScope(null, "Global");
-		ScopeInstance globalInst = new SimpleScopeInstance(null, globalScope);
-		LegalScope spScope = new SimpleLegalScope(globalScope, "Spell");
+		varScopeLib.registerScope(globalScope);
+		ScopeInstance globalInst =
+				instanceFactory.getInstance(null, "Global", null);
 		LegalScope eqScope = new SimpleLegalScope(globalScope, "Equipment");
-		ScopeInstance eqInst = new SimpleScopeInstance(globalInst, eqScope);
+		varScopeLib.registerScope(eqScope);
+		LegalScope spScope = new SimpleLegalScope(globalScope, "Spell");
+		varScopeLib.registerScope(spScope);
+		ScopeInstance eqInst = instanceFactory.getInstance(globalInst, "Equipment", null);
 		try
 		{
 			varLib.getVariableID(null, "Walk");
@@ -410,13 +415,15 @@ public class VariableLibraryTest extends TestCase
 	public void testGetVID()
 	{
 		LegalScope globalScope = new SimpleLegalScope(null, "Global");
+		varScopeLib.registerScope(globalScope);
 		ScopeInstance globalInst =
-				new SimpleScopeInstance(null, globalScope);
+				instanceFactory.getInstance(null, "Global", null);
 		LegalScope eqScope = new SimpleLegalScope(globalScope, "Equipment");
-		ScopeInstance eqInst = new SimpleScopeInstance(globalInst, eqScope);
+		varScopeLib.registerScope(eqScope);
+		ScopeInstance eqInst = instanceFactory.getInstance(globalInst, "Equipment", null);
 		LegalScope eqPartScope = new SimpleLegalScope(eqScope, "Part");
-		ScopeInstance eqPartInst =
-				new SimpleScopeInstance(eqInst, eqPartScope);
+		varScopeLib.registerScope(eqPartScope);
+		ScopeInstance eqPartInst = instanceFactory.getInstance(eqInst, "Part", null);
 		assertTrue(varLib.assertLegalVariableID("Walk", globalScope, numberManager));
 		assertTrue(varLib.assertLegalVariableID("Float", eqScope, numberManager));
 		assertTrue(varLib.assertLegalVariableID("Hover", eqPartScope, numberManager));
@@ -491,16 +498,18 @@ public class VariableLibraryTest extends TestCase
 	{
 		BooleanManager booleanManager = FormatUtilities.BOOLEAN_MANAGER;
 		SimpleLegalScope globalScope = new SimpleLegalScope(null, "Global");
-		ScopeInstance globalInst =
-				new SimpleScopeInstance(null, globalScope);
+		varScopeLib.registerScope(globalScope);
+		ScopeInstance globalInst = instanceFactory.getInstance(null, "Global", null);
 		SimpleLegalScope eqScope =
 				new SimpleLegalScope(globalScope, "Equipment");
+		varScopeLib.registerScope(eqScope);
 		ScopeInstance eqInst =
-				new SimpleScopeInstance(globalInst, eqScope);
+				instanceFactory.getInstance(globalInst, "Equipment", null);
 		SimpleLegalScope abScope =
 				new SimpleLegalScope(globalScope, "Ability");
+		varScopeLib.registerScope(abScope);
 		ScopeInstance abInst =
-				new SimpleScopeInstance(globalInst, abScope);
+				instanceFactory.getInstance(globalInst, "Ability", null);
 
 		assertTrue(varLib.assertLegalVariableID("Walk", eqScope, numberManager));
 		VariableID vidm = varLib.getVariableID(eqInst, "Walk");

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/ScopeInstanceFactoryTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/ScopeInstanceFactoryTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2016 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.formula.inst;
+
+import org.junit.Test;
+
+import junit.framework.TestCase;
+import pcgen.base.formula.base.LegalScopeLibrary;
+import pcgen.base.formula.base.ScopeInstance;
+import pcgen.base.formula.base.VarScoped;
+
+public class ScopeInstanceFactoryTest extends TestCase
+{
+
+	private ScopeInstanceFactory factory;
+	private LegalScopeLibrary library;
+	private SimpleLegalScope scope;
+	private ScopeInstance scopeInst;
+	private SimpleLegalScope local;
+	private ScopeInstance localInst;
+
+	@Override
+	protected void setUp() throws Exception
+	{
+		super.setUp();
+		library = new LegalScopeLibrary();
+		factory = new ScopeInstanceFactory(library);
+		scope = new SimpleLegalScope(null, "Global");
+		library.registerScope(scope);
+		scopeInst = factory.getInstance(null, "Global", null);
+		local = new SimpleLegalScope(scope, "Local");
+		library.registerScope(local);
+		localInst = factory.getInstance(scopeInst, "Local", null);
+	}
+
+	@Test
+	public void testConstructor()
+	{
+		try
+		{
+			new ScopeInstanceFactory(null);
+			fail("null library must be rejected");
+		}
+		catch (NullPointerException e)
+		{
+			//ok
+		}
+		catch (IllegalArgumentException e)
+		{
+			//ok, too			
+		}
+	}
+
+	@Test
+	public void testGetInstance()
+	{
+		try
+		{
+			factory.getInstance(null, "Name", null);
+			fail("Expected to fail due to no global scope called name");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//ok
+		}
+		try
+		{
+			factory.getInstance(scopeInst, null, null);
+			fail("Expected to fail due to invalid subscope name");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//ok
+		}
+		SimpleLegalScope sublocal = new SimpleLegalScope(local, "SubLocal");
+		library.registerScope(sublocal);
+		try
+		{
+			factory.getInstance(scopeInst, "SubLocal", null);
+			fail("Expected to fail due to invalid parent scope instance");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//ok
+		}
+		ScopeInstance globalInst = factory.getInstance(null, "Global", null);
+		assertNull(globalInst.getParentScope());
+		assertEquals("Global", globalInst.getLegalScope().getName());
+
+		ScopeInstance localInst = factory.getInstance(globalInst, "Local", null);
+		assertTrue(local.equals(localInst.getLegalScope()));
+		assertTrue(globalInst.equals(localInst.getParentScope()));
+		assertEquals("Local", localInst.getLegalScope().getName());
+	}
+
+	public void testGetGlobalInstance()
+	{
+		try
+		{
+			factory.getGlobalInstance("Local");
+			fail("Expected failure due to non global scope");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//ok
+		}
+		ScopeInstance globalInst = factory.getGlobalInstance("Global");
+		assertNull(globalInst.getParentScope());
+		assertEquals("Global", globalInst.getLegalScope().getName());
+		assertEquals(scopeInst, globalInst);
+	}
+
+	public void testGet()
+	{
+		ScopeInstance gsi = factory.get("Global", null);
+		assertNull(gsi.getParentScope());
+		assertEquals("Global", gsi.getLegalScope().getName());
+
+		/*
+		 * This is subtle, but important.
+		 * 
+		 * The case above of "null" being the argument means that it is "truly"
+		 * the global scope - it's global being requested as "known" global.
+		 * 
+		 * The case below represents a "local" object without a unique scope -
+		 * so the only valid scope is the global scope. Therefore, it's
+		 * requested with a VarScoped object, but we expect the returned value
+		 * to still be the global scope. We can see that in the equals tests
+		 * below of si and gsi.
+		 */
+		Scoped gvs = new Scoped("Var", null, null);
+		ScopeInstance si = factory.get("Global", gvs);
+		assertNull(si.getParentScope());
+		assertEquals("Global", si.getLegalScope().getName());
+		assertEquals(si, gsi);
+		assertTrue(si == gsi);
+
+		try
+		{
+			factory.get("Local", gvs);
+			fail("Mixmatch Local and Global should fail");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//ok
+		}
+		try
+		{
+			factory.get("Local", null);
+			fail("Mixmatch Local and Global should fail");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//ok
+		}
+		Scoped lvs = new Scoped("LVar", "Local", gvs);
+		ScopeInstance lsi = factory.get("Local", lvs);
+		assertTrue(local.equals(lsi.getLegalScope()));
+		assertTrue(scopeInst.equals(lsi.getParentScope()));
+		assertEquals("Local", lsi.getLegalScope().getName());
+
+		SimpleLegalScope sublocal = new SimpleLegalScope(local, "SubLocal");
+		library.registerScope(sublocal);
+		Scoped slvs = new Scoped("SVar", "SubLocal", lvs);
+		ScopeInstance slsi = factory.get("Local", slvs);
+		assertTrue(local.equals(slsi.getLegalScope()));
+		assertTrue(scopeInst.equals(slsi.getParentScope()));
+		assertEquals("Local", slsi.getLegalScope().getName());
+
+	}
+
+	public class Scoped implements VarScoped
+	{
+
+		private final String name;
+		private final String scopeName;
+		private final VarScoped parent;
+
+		public Scoped(String s, String scopeName, VarScoped parent)
+		{
+			name = s;
+			this.scopeName = scopeName;
+			this.parent = parent;
+		}
+
+		@Override
+		public String getKeyName()
+		{
+			return name;
+		}
+
+		@Override
+		public String getLocalScopeName()
+		{
+			return scopeName;
+		}
+
+		@Override
+		public VarScoped getVariableParent()
+		{
+			return parent;
+		}
+
+	}
+}

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleLegalScopeTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleLegalScopeTest.java
@@ -1,5 +1,4 @@
 /*
-/*
  * Copyright 2016 (C) Tom Parker <thpr@users.sourceforge.net>
  * 
  * This library is free software; you can redistribute it and/or modify it under

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleScopeInstanceTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleScopeInstanceTest.java
@@ -40,7 +40,7 @@ public class SimpleScopeInstanceTest extends TestCase
 	}
 
 	@Test
-	public void testDoubleConstructor()
+	public void testConstructor()
 	{
 		try
 		{
@@ -86,6 +86,38 @@ public class SimpleScopeInstanceTest extends TestCase
 		{
 			//ok, too			
 		}
+		SimpleLegalScope sublocal = new SimpleLegalScope(local, "SubLocal");
+		SimpleScopeInstance globalInst = new SimpleScopeInstance(null, scope);
+		try
+		{
+			new SimpleScopeInstance(null, local);
+			fail("Instance should require a parent if not global");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//ok
+		}
+		SimpleScopeInstance localInst = new SimpleScopeInstance(globalInst, local);
+		assertEquals(globalInst, localInst.getParentScope());
+		assertEquals(local, localInst.getLegalScope());
+		try
+		{
+			new SimpleScopeInstance(globalInst, null);
+			fail("LegalScope cannot be null");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//ok
+		}
+		try
+		{
+			new SimpleScopeInstance(globalInst, sublocal);
+			fail("LegalScope must be a direct child of the scope of the provided instance");
+		}
+		catch (IllegalArgumentException e)
+		{
+			//ok
+		}
 	}
 
 	@Test
@@ -94,4 +126,5 @@ public class SimpleScopeInstanceTest extends TestCase
 		assertEquals(local, localInst.getLegalScope());
 		assertEquals(scopeInst, localInst.getParentScope());
 	}
+
 }

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleVariableStoreTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleVariableStoreTest.java
@@ -20,19 +20,30 @@ package pcgen.base.formula.inst;
 import junit.framework.TestCase;
 import pcgen.base.format.NumberManager;
 import pcgen.base.formatmanager.FormatUtilities;
-import pcgen.base.formula.base.LegalScope;
+import pcgen.base.formula.base.LegalScopeLibrary;
 import pcgen.base.formula.base.ScopeInstance;
 import pcgen.base.formula.base.VariableID;
 
 public class SimpleVariableStoreTest extends TestCase
 {
 
+	private LegalScopeLibrary library;
+	private ScopeInstanceFactory instanceFactory;
+		
+	@Override
+	protected void setUp() throws Exception
+	{
+		super.setUp();
+		library = new LegalScopeLibrary();
+		library.registerScope(new SimpleLegalScope(null, "Global"));
+		instanceFactory = new ScopeInstanceFactory(library);
+	}
+
 	public void testNulls()
 	{
 		SimpleVariableStore varStore = new SimpleVariableStore();
 		NumberManager numberManager = new NumberManager();
-		LegalScope varScope = new SimpleLegalScope(null, "Global");
-		ScopeInstance globalInst = new SimpleScopeInstance(null, varScope);
+		ScopeInstance globalInst = instanceFactory.getInstance(null, "Global", null);
 		VariableID<Number> vid = new VariableID<>(globalInst, numberManager, "test");
 		try
 		{
@@ -67,8 +78,7 @@ public class SimpleVariableStoreTest extends TestCase
 	{
 		SimpleVariableStore varStore = new SimpleVariableStore();
 		NumberManager numberManager = FormatUtilities.NUMBER_MANAGER;
-		LegalScope varScope = new SimpleLegalScope(null, "Global");
-		ScopeInstance globalInst = new SimpleScopeInstance(null, varScope);
+		ScopeInstance globalInst = instanceFactory.getInstance(null, "Global", null);
 		VariableID vid = new VariableID(globalInst, numberManager, "test");
 		assertFalse(varStore.containsKey(vid));
 		assertNull(varStore.put(vid, Integer.valueOf(9)));
@@ -83,12 +93,12 @@ public class SimpleVariableStoreTest extends TestCase
 	{
 		SimpleVariableStore varStore = new SimpleVariableStore();
 		NumberManager numberManager = new NumberManager();
-		LegalScope varScope = new SimpleLegalScope(null, "Global");
-		ScopeInstance globalInst = new SimpleScopeInstance(null, varScope);
+		ScopeInstance globalInst = instanceFactory.getInstance(null, "Global", null);
 		VariableID vid1 = new VariableID(globalInst, numberManager, "test");
 		VariableID vid2 = new VariableID(globalInst, numberManager, "test");
 		VariableID vid3 = new VariableID(globalInst, numberManager, "test2");
-		ScopeInstance globalInst2 = new SimpleScopeInstance(null, varScope);
+		library.registerScope(new SimpleLegalScope(null, "Global2"));
+		ScopeInstance globalInst2 = instanceFactory.getInstance(null, "Global2", null);
 		VariableID vid4 = new VariableID(globalInst2, numberManager, "test");
 		assertNull(varStore.put(vid1, Integer.valueOf(9)));
 		assertTrue(varStore.containsKey(vid1));

--- a/PCGen-Formula/code/src/test/pcgen/base/testsupport/AbstractFormulaTestCase.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/testsupport/AbstractFormulaTestCase.java
@@ -148,7 +148,7 @@ public abstract class AbstractFormulaTestCase extends TestCase
 	{
 		VariableLibrary variableLibrary = getVariableLibrary();
 		variableLibrary.assertLegalVariableID(formula,
-			localSetup.getGlobalScope(), numberManager);
+			localSetup.getGlobalScopeInst().getLegalScope(), numberManager);
 		return (VariableID<Number>) variableLibrary.getVariableID(
 			localSetup.getGlobalScopeInst(), formula);
 	}
@@ -157,7 +157,8 @@ public abstract class AbstractFormulaTestCase extends TestCase
 	{
 		VariableLibrary variableLibrary = getVariableLibrary();
 		variableLibrary.assertLegalVariableID(formula,
-			localSetup.getGlobalScope(), FormatUtilities.BOOLEAN_MANAGER);
+			localSetup.getGlobalScopeInst().getLegalScope(),
+			FormatUtilities.BOOLEAN_MANAGER);
 		return (VariableID<Boolean>) variableLibrary.getVariableID(
 			localSetup.getGlobalScopeInst(), formula);
 	}
@@ -185,7 +186,7 @@ public abstract class AbstractFormulaTestCase extends TestCase
 
 	protected LegalScope getGlobalScope()
 	{
-		return localSetup.getGlobalScope();
+		return localSetup.getGlobalScopeInst().getLegalScope();
 	}
 
 	protected ScopeInstance getGlobalScopeInst()


### PR DESCRIPTION
Tightly depend on LegalScopelibrary rather than depend in certain cases
and not others.  This will avoid additional error checking and potential
ambiguities

Bug Fix for pulling Global Scope Instance
