### PR TITLE
Fix Failure case for Variable Lookup

### DIFF
--- a/PCGen-Formula/code/src/java/pcgen/base/formula/base/DefaultStore.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/base/DefaultStore.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.formula.base;
+
+public interface DefaultStore
+{
+	/**
+	 * Returns the default value for a given Format (provided as a Class).
+	 * 
+	 * @param <T>
+	 *            The format (class) of object for which the default value
+	 *            should be returned
+	 * @param varFormat
+	 *            The Class (data format) for which the default value should be
+	 *            returned
+	 * @return The default value for the given Format
+	 */
+	public <T> T getDefault(Class<T> varFormat);
+}

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/base/FormulaManager.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/base/FormulaManager.java
@@ -83,4 +83,13 @@ public interface FormulaManager
 	 */
 	public FormulaManager swapFunctionLibrary(FunctionLibrary ftnLib);
 
+	/**
+	 * Returns the default value for a given format (class).
+	 * 
+	 * @param The
+	 *            format for which the default value should be returned
+	 * @return The default value for a given format (class)
+	 */
+	public <T> T getDefault(Class<T> format);
+
 }

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/inst/SimpleFormulaManager.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/inst/SimpleFormulaManager.java
@@ -17,6 +17,9 @@
  */
 package pcgen.base.formula.inst;
 
+import java.util.Objects;
+
+import pcgen.base.formula.base.DefaultStore;
 import pcgen.base.formula.base.FormulaManager;
 import pcgen.base.formula.base.FunctionLibrary;
 import pcgen.base.formula.base.OperatorLibrary;
@@ -39,6 +42,12 @@ import pcgen.base.formula.base.VariableStore;
  */
 public class SimpleFormulaManager implements FormulaManager
 {
+	
+	/**
+	 * The DefaultStore used to know the default values for a format (class).
+	 */
+	private final DefaultStore defaultStore;
+
 	/**
 	 * The FunctionLibrary used to store valid functions in this FormulaManager.
 	 */
@@ -76,37 +85,21 @@ public class SimpleFormulaManager implements FormulaManager
 	 * @param resultStore
 	 *            The VariableStore used to hold variables values for items
 	 *            processed through this FormulaManager
+	 * @param defaultStore
+	 *            The DefaultStore used to know default values for each format
+	 *            (class)
 	 * @throws IllegalArgumentException
 	 *             if any parameter is null
 	 */
 	public SimpleFormulaManager(FunctionLibrary ftnLibrary,
 		OperatorLibrary opLibrary, VariableLibrary varLibrary,
-		VariableStore resultStore)
+		VariableStore resultStore, DefaultStore defaultStore)
 	{
-		if (ftnLibrary == null)
-		{
-			throw new IllegalArgumentException(
-				"Cannot build FormulaManager with null FunctionLibrary");
-		}
-		if (opLibrary == null)
-		{
-			throw new IllegalArgumentException(
-				"Cannot build FormulaManager with null OperatorLibrary");
-		}
-		if (varLibrary == null)
-		{
-			throw new IllegalArgumentException(
-				"Cannot build FormulaManager with null VariableLibrary");
-		}
-		if (resultStore == null)
-		{
-			throw new IllegalArgumentException(
-				"Cannot build FormulaManager with null VariableStore");
-		}
-		this.ftnLibrary = ftnLibrary;
-		this.opLibrary = opLibrary;
-		this.varLibrary = varLibrary;
-		this.results = resultStore;
+		this.ftnLibrary = Objects.requireNonNull(ftnLibrary);
+		this.opLibrary = Objects.requireNonNull(opLibrary);
+		this.varLibrary = Objects.requireNonNull(varLibrary);
+		this.results = Objects.requireNonNull(resultStore);
+		this.defaultStore = Objects.requireNonNull(defaultStore);
 	}
 
 	/**
@@ -174,7 +167,25 @@ public class SimpleFormulaManager implements FormulaManager
 	@Override
 	public FormulaManager swapFunctionLibrary(FunctionLibrary ftnLib)
 	{
-		return new SimpleFormulaManager(ftnLib, opLibrary, varLibrary, results);
+		return new SimpleFormulaManager(ftnLib, opLibrary, varLibrary, results,
+			defaultStore);
+	}
+
+	/**
+	 * Returns the default value for a given Format (provided as a Class).
+	 * 
+	 * @param <T>
+	 *            The format (class) of object for which the default value
+	 *            should be returned
+	 * @param varFormat
+	 *            The Class (data format) for which the default value should be
+	 *            returned
+	 * @return The default value for the given Format
+	 */
+	@Override
+	public <T> T getDefault(Class<T> format)
+	{
+		return defaultStore.getDefault(format);
 	}
 
 }

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/visitor/EvaluateVisitor.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/visitor/EvaluateVisitor.java
@@ -382,13 +382,18 @@ public class EvaluateVisitor implements FormulaParserVisitor
 				return resolver.get(id);
 			}
 		}
+		Class<?> asserted = manager.peek(EvaluationManager.ASSERTED);
+		if (asserted == null)
+		{
+			System.out
+				.println("Evaluation called on invalid variable: '" + varName
+					+ "', no asserted format available to determine default, "
+					+ "assuming zero (number)");
+			return 0;
+		}
 		System.out.println("Evaluation called on invalid variable: '" + varName
-			+ "', assuming default");
-		//argh! not always integer!!
-		return Integer.valueOf(0);
-		//		throw new IllegalStateException(
-		//			"Evaluation called on invalid Formula (reached invalid non-term: "
-		//				+ termName + ")");
+			+ "', assuming default for " + asserted.getSimpleName());
+		return fm.getDefault(asserted);
 	}
 
 }

--- a/PCGen-Formula/code/src/java/pcgen/base/solver/IndividualSetup.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/solver/IndividualSetup.java
@@ -78,7 +78,7 @@ public class IndividualSetup
 		formulaManager =
 				new SimpleFormulaManager(parent.getFunctionLibrary(),
 					parent.getOperatorLibrary(), parent.getVariableLibrary(),
-					getVariableStore());
+					getVariableStore(), parent.getSolverFactory());
 		globalScopeInst = instanceFactory.getInstance(null, globalName, null);
 	}
 

--- a/PCGen-Formula/code/src/java/pcgen/base/solver/SolverFactory.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/solver/SolverFactory.java
@@ -20,6 +20,7 @@ package pcgen.base.solver;
 import java.util.HashMap;
 import java.util.Map;
 
+import pcgen.base.formula.base.DefaultStore;
 import pcgen.base.formula.base.EvaluationManager;
 import pcgen.base.util.FormatManager;
 
@@ -30,7 +31,7 @@ import pcgen.base.util.FormatManager;
  * 
  * The format of Solver is represented by a Class object.
  */
-public class SolverFactory
+public class SolverFactory implements DefaultStore
 {
 
 	/**
@@ -160,6 +161,7 @@ public class SolverFactory
 	 *            returned
 	 * @return The default value for the given Format
 	 */
+	@Override
 	public <T> T getDefault(Class<T> varFormat)
 	{
 		@SuppressWarnings("unchecked")

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleFormulaManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleFormulaManagerTest.java
@@ -17,12 +17,12 @@
  */
 package pcgen.base.formula.inst;
 
-import junit.framework.TestCase;
-
 import org.junit.Test;
 
+import junit.framework.TestCase;
 import pcgen.base.formula.base.LegalScopeLibrary;
 import pcgen.base.formula.base.VariableLibrary;
+import pcgen.base.solver.SolverFactory;
 
 public class SimpleFormulaManagerTest extends TestCase
 {
@@ -32,6 +32,7 @@ public class SimpleFormulaManagerTest extends TestCase
 	private SimpleFunctionLibrary ftnLibrary;
 	private SimpleOperatorLibrary opLibrary;
 	private SimpleVariableStore resultsStore;
+	private SolverFactory defaultStore;
 
 	@Override
 	protected void setUp() throws Exception
@@ -42,6 +43,7 @@ public class SimpleFormulaManagerTest extends TestCase
 		opLibrary = new SimpleOperatorLibrary();
 		ftnLibrary = new SimpleFunctionLibrary();
 		resultsStore = new SimpleVariableStore();
+		defaultStore = new SolverFactory();
 	}
 
 	@Test
@@ -49,7 +51,7 @@ public class SimpleFormulaManagerTest extends TestCase
 	{
 		try
 		{
-			new SimpleFormulaManager(null, null, null, null);
+			new SimpleFormulaManager(null, null, null, null, null);
 			fail("nulls must be rejected");
 		}
 		catch (NullPointerException e)
@@ -62,7 +64,8 @@ public class SimpleFormulaManagerTest extends TestCase
 		}
 		try
 		{
-			new SimpleFormulaManager(null, opLibrary, varLibrary, resultsStore);
+			new SimpleFormulaManager(null, opLibrary, varLibrary, resultsStore,
+				defaultStore);
 			fail("null ftn lib must be rejected");
 		}
 		catch (NullPointerException e)
@@ -75,7 +78,8 @@ public class SimpleFormulaManagerTest extends TestCase
 		}
 		try
 		{
-			new SimpleFormulaManager(ftnLibrary, null, varLibrary, resultsStore);
+			new SimpleFormulaManager(ftnLibrary, null, varLibrary, resultsStore,
+				defaultStore);
 			fail("null op lib must be rejected");
 		}
 		catch (NullPointerException e)
@@ -88,7 +92,8 @@ public class SimpleFormulaManagerTest extends TestCase
 		}
 		try
 		{
-			new SimpleFormulaManager(ftnLibrary, opLibrary, null, resultsStore);
+			new SimpleFormulaManager(ftnLibrary, opLibrary, null, resultsStore,
+				defaultStore);
 			fail("null var lib must be rejected");
 		}
 		catch (NullPointerException e)
@@ -101,8 +106,23 @@ public class SimpleFormulaManagerTest extends TestCase
 		}
 		try
 		{
-			new SimpleFormulaManager(ftnLibrary, opLibrary, varLibrary, null);
+			new SimpleFormulaManager(ftnLibrary, opLibrary, varLibrary, null,
+				defaultStore);
 			fail("null results must be rejected");
+		}
+		catch (NullPointerException e)
+		{
+			//ok
+		}
+		catch (IllegalArgumentException e)
+		{
+			//ok, too			
+		}
+		try
+		{
+			new SimpleFormulaManager(ftnLibrary, opLibrary, varLibrary,
+				resultsStore, null);
+			fail("null defaults must be rejected");
 		}
 		catch (NullPointerException e)
 		{


### PR DESCRIPTION
Previously, when the Formula system encountered an unknown variable, it injected "zero" (the numeric value).  Now, it is at least aware of the assumed variable type, such that it can inject a more useful value.  This is not strictly necessary in situations where the variables are properly defined, but still a better design than always assuming the unknown is a number.
