### PR TITLE
Bump ca.coglinc.javacc to 2.4.0 (as previously done)

### DIFF
--- a/PCGen-Formula/build.gradle
+++ b/PCGen-Formula/build.gradle
@@ -8,7 +8,7 @@
  * Full build: gradle all 
  */
 plugins {
-    id "ca.coglinc.javacc" version "2.3.1"
+    id "ca.coglinc.javacc" version "2.4.0"
     id 'java'
     id 'eclipse'
     id 'jacoco'


### PR DESCRIPTION
This reduces the difference between HEAD and #131's parent