### PR TITLE
Allow Dependency calculation to know the semantics

### DIFF
--- a/PCGen-Formula/code/src/java/pcgen/base/formula/base/DependencyManager.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/base/DependencyManager.java
@@ -58,6 +58,13 @@ public class DependencyManager
 	public static final TypedKey<FormatManager<?>> ASSERTED = new TypedKey<>();
 
 	/**
+	 * A TypedKey used for storing the Format of the input object for the formula served
+	 * by this DependencyManager.
+	 */
+	public static final TypedKey<FormatManager<?>> INPUT_FORMAT =
+			new TypedKey<FormatManager<?>>();
+
+	/**
 	 * A TypedKey used for storing the dynamic variables for the formula served by this
 	 * DependencyManager.
 	 */

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/base/Function.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/base/Function.java
@@ -231,8 +231,10 @@ public interface Function
 	 *            The DependencyManager used to support analysis of the Function
 	 * @param args
 	 *            The arguments to this Function within the Formula
+	 * @return a FormatManager indicating the format of the value returned by this
+	 *         Function
 	 */
-	void getDependencies(DependencyVisitor visitor, DependencyManager manager,
+	FormatManager<?> getDependencies(DependencyVisitor visitor, DependencyManager manager,
 		Node[] args);
 
 	/*

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/function/AbstractNaryFunction.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/function/AbstractNaryFunction.java
@@ -155,13 +155,14 @@ public abstract class AbstractNaryFunction implements Function
 	 * {@inheritDoc}
 	 */
 	@Override
-	public void getDependencies(DependencyVisitor visitor,
+	public FormatManager<?> getDependencies(DependencyVisitor visitor,
 		DependencyManager manager, Node[] args)
 	{
 		for (Node n : args)
 		{
 			n.jjtAccept(visitor, manager);
 		}
+		return FormatUtilities.NUMBER_MANAGER;
 	}
 
 	/**

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/function/AbstractUnaryFunction.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/function/AbstractUnaryFunction.java
@@ -125,10 +125,10 @@ public abstract class AbstractUnaryFunction implements Function
 	 * {@inheritDoc}
 	 */
 	@Override
-	public void getDependencies(DependencyVisitor visitor,
+	public FormatManager<?> getDependencies(DependencyVisitor visitor,
 		DependencyManager manager, Node[] args)
 	{
-		args[0].jjtAccept(visitor, manager);
+		return (FormatManager<?>) args[0].jjtAccept(visitor, manager);
 	}
 
 	/**

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/function/IfFunction.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/function/IfFunction.java
@@ -189,12 +189,13 @@ public class IfFunction implements Function
 	 * {@inheritDoc}
 	 */
 	@Override
-	public void getDependencies(DependencyVisitor visitor,
+	public FormatManager<?> getDependencies(DependencyVisitor visitor,
 		DependencyManager manager, Node[] args)
 	{
 		args[0].jjtAccept(visitor,
 			manager.getWith(DependencyManager.ASSERTED, FormatUtilities.BOOLEAN_MANAGER));
-		args[1].jjtAccept(visitor, manager);
+		FormatManager<?> tFormat = (FormatManager<?>) args[1].jjtAccept(visitor, manager);
 		args[2].jjtAccept(visitor, manager);
+		return tFormat;
 	}
 }

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/function/ValueFunction.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/function/ValueFunction.java
@@ -81,9 +81,10 @@ public class ValueFunction implements Function
 	}
 
 	@Override
-	public void getDependencies(DependencyVisitor visitor,
+	public FormatManager<?> getDependencies(DependencyVisitor visitor,
 		DependencyManager manager, Node[] args)
 	{
+		return manager.get(DependencyManager.INPUT_FORMAT);
 	}
 
 }

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/library/ArgFunction.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/library/ArgFunction.java
@@ -159,7 +159,7 @@ public class ArgFunction implements Function
 	 * {@inheritDoc}
 	 */
 	@Override
-	public void getDependencies(DependencyVisitor visitor,
+	public FormatManager<?> getDependencies(DependencyVisitor visitor,
 		DependencyManager manager, Node[] args)
 	{
 		ASTNum node = (ASTNum) args[0];
@@ -177,6 +177,6 @@ public class ArgFunction implements Function
 		{
 			argManager.addArgument(argNum);
 		}
-		visitor.visit((SimpleNode) masterArgs[argNum], manager);
+		return (FormatManager<?>) visitor.visit((SimpleNode) masterArgs[argNum], manager);
 	}
 }

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/library/GenericFunction.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/library/GenericFunction.java
@@ -194,13 +194,14 @@ public class GenericFunction implements Function
 	 * {@inheritDoc}
 	 */
 	@Override
-	public void getDependencies(DependencyVisitor visitor,
+	public FormatManager<?> getDependencies(DependencyVisitor visitor,
 		DependencyManager manager, Node[] args)
 	{
 		FormulaManager formulaManager = manager.get(DependencyManager.FMANAGER);
 		FunctionLibrary withArgs = new ArgWrappingLibrary(
 			formulaManager.get(FormulaManager.FUNCTION), args);
 		FormulaManager subFtn = formulaManager.getWith(FormulaManager.FUNCTION, withArgs);
-		visitor.visit(root, manager.getWith(DependencyManager.FMANAGER, subFtn));
+		return (FormatManager<?>) visitor.visit(root,
+			manager.getWith(DependencyManager.FMANAGER, subFtn));
 	}
 }

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/ComplexNEPFormulaTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/ComplexNEPFormulaTest.java
@@ -188,7 +188,8 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 			depManager.get(ArgumentDependencyManager.KEY).getMaximumArgument());
 
 		depManager = setupDM();
-		new ComplexNEPFormula<>("value()").getDependencies(depManager);
+		new ComplexNEPFormula<>("value()").getDependencies(
+			depManager.getWith(DependencyManager.INPUT_FORMAT, numberManager));
 		assertTrue(depManager.get(DependencyManager.VARIABLES).getVariables().isEmpty());
 		assertEquals(-1,
 			depManager.get(ArgumentDependencyManager.KEY).getMaximumArgument());

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleFunctionLibraryTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleFunctionLibraryTest.java
@@ -142,9 +142,10 @@ public class SimpleFunctionLibraryTest extends TestCase
 			}
 
 			@Override
-			public void getDependencies(DependencyVisitor visitor,
+			public FormatManager<?> getDependencies(DependencyVisitor visitor,
 				DependencyManager manager, Node[] args)
 			{
+				return null;
 			}
 		};
 	}

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/library/ArgWrappingLibraryTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/library/ArgWrappingLibraryTest.java
@@ -137,9 +137,10 @@ public class ArgWrappingLibraryTest extends AbstractFormulaTestCase
 			}
 
 			@Override
-			public void getDependencies(DependencyVisitor visitor,
+			public FormatManager<?> getDependencies(DependencyVisitor visitor,
 				DependencyManager manager, Node[] args)
 			{
+				return null;
 			}
 		};
 	}

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/DynamicSolverManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/DynamicSolverManagerTest.java
@@ -368,7 +368,7 @@ public class DynamicSolverManagerTest extends AbstractSolverManagerTest
 		}
 
 		@Override
-		public void getDependencies(DependencyVisitor visitor, DependencyManager dm,
+		public FormatManager<?> getDependencies(DependencyVisitor visitor, DependencyManager dm,
 			Node[] args)
 		{
 			String varName = ((SimpleNode) args[0]).getText();
@@ -378,8 +378,9 @@ public class DynamicSolverManagerTest extends AbstractSolverManagerTest
 			visitor.visitVariable(varName, trainer);
 			DynamicDependency dd = new DynamicDependency(ts.getControlVar(), "LIMB");
 			DependencyManager dynamic = dm.getWith(DependencyManager.VARSTRATEGY, dd);
-			visitor.visitVariable(name, dynamic);
+			FormatManager<?> returnFormat = visitor.visitVariable(name, dynamic);
 			dm.get(DependencyManager.DYNAMIC).addDependency(dd);
+			return returnFormat;
 		}
 	}
 


### PR DESCRIPTION
Improves what functions can do with dependency analysis.

This makes the Dependency analysis return the format of the object being processed, thus allowing functions which might depend on the format of the first argument to validate or derive other dependencies later on in that function.  The "lookup" function in the main repository will have some TODO items able to be resolved after this change.
