### PR TITLE
Fix so that DependencyVisitor can run without INSTANCE

### DIFF
--- a/PCGen-Formula/code/src/java/pcgen/base/formula/base/DependencyManager.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/base/DependencyManager.java
@@ -47,7 +47,18 @@ public class DependencyManager
 	public static final TypedKey<FormulaManager> FMANAGER = new TypedKey<>();
 
 	/**
-	 * A TypedKey used for storing the ScopeInstance contained in this DependencyManager
+	 * A TypedKey used for storing the LegalScope contained in this DependencyManager.
+	 * 
+	 * The SCOPE TypedKey is required if the INSTANCE TypedKey is not used.  Otherwise,
+	 * for DependencyVisitor it is optional.
+	 */
+	public static final TypedKey<LegalScope> SCOPE = new TypedKey<>();
+
+	/**
+	 * A TypedKey used for storing the ScopeInstance contained in this DependencyManager.
+	 * 
+	 * The INSTANCE TypedKey is optional; it may be required by some VariableStrategy
+	 * objects or other specific situations.
 	 */
 	public static final TypedKey<ScopeInstance> INSTANCE = new TypedKey<>();
 

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/inst/GlobalVarScoped.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/inst/GlobalVarScoped.java
@@ -63,4 +63,9 @@ public class GlobalVarScoped implements VarScoped
 		return null;
 	}
 
+	@Override
+	public String toString()
+	{
+		return "Global Variable Scope";
+	}
 }

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/visitor/DependencyVisitor.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/visitor/DependencyVisitor.java
@@ -229,13 +229,12 @@ public class DependencyVisitor implements FormulaParserVisitor
 	 */
 	public FormatManager<?> visitVariable(String varName, DependencyManager manager)
 	{
-		FormatManager<?> formatManager = getVariableFormat(manager, varName);
 		VariableStrategy varStrategy = manager.get(DependencyManager.VARSTRATEGY);
 		if (varStrategy != null)
 		{
 			varStrategy.addVariable(manager, varName);
 		}
-		return formatManager;
+		return getVariableFormat(manager, varName);
 	}
 
 	/**
@@ -253,7 +252,12 @@ public class DependencyVisitor implements FormulaParserVisitor
 	public FormatManager<?> getVariableFormat(DependencyManager manager, String varName)
 	{
 		VariableLibrary varLib = manager.get(DependencyManager.FMANAGER).getFactory();
-		LegalScope legalScope = manager.get(DependencyManager.INSTANCE).getLegalScope();
+		LegalScope legalScope = manager.get(DependencyManager.SCOPE);
+		if (legalScope == null)
+		{
+			//Fall back to INSTANCE
+			legalScope = manager.get(DependencyManager.INSTANCE).getLegalScope();
+		}
 		return varLib.getVariableFormat(legalScope, varName);
 	}
 


### PR DESCRIPTION
Allowed as long as SCOPE is provided.

Also provides a minor fix to help GLOBAL appear better in the PCGen Solver View

The main part of this is a fix so that this can be merged into the main PCGen repository without errors.  Library 145 when merged produces test errors due to a stack dump