### PR TITLE
Allow Direct Solving & Change scope of Asserted value

### DIFF
--- a/PCGen-Formula/code/src/java/pcgen/base/formula/base/ManagerFactory.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/base/ManagerFactory.java
@@ -17,8 +17,6 @@
  */
 package pcgen.base.formula.base;
 
-import pcgen.base.util.FormatManager;
-
 /**
  * A ManagerFactory is an object designed to produce the various manager objects used by
  * the visitors to a Formula. This is an interface to allow extension of these behaviors
@@ -33,18 +31,13 @@ public interface ManagerFactory
 	 *            The FormulaManager to be contained in the DependencyManager
 	 * @param scopeInst
 	 *            The ScopeInstance to be contained in the DependencyManager
-	 * @param assertedFormat
-	 *            The FormatManager for the Format (class) currently asserted for the
-	 *            formula served by the DependencyManager
 	 * @return An initialized DependencyManager with the given arguments
 	 */
 	public default DependencyManager generateDependencyManager(
-		FormulaManager formulaManager, ScopeInstance scopeInst,
-		FormatManager<?> assertedFormat)
+		FormulaManager formulaManager, ScopeInstance scopeInst)
 	{
 		DependencyManager fdm = new DependencyManager(formulaManager);
-		fdm = fdm.getWith(DependencyManager.INSTANCE, scopeInst);
-		return fdm.getWith(DependencyManager.ASSERTED, assertedFormat);
+		return fdm.getWith(DependencyManager.INSTANCE, scopeInst);
 	}
 
 	/**
@@ -71,19 +64,15 @@ public interface ManagerFactory
 	 *            FormulaSemantics
 	 * @param legalScope
 	 *            The LegalScope when a Formula is processed with this FormulaSemantics
-	 * @param assertedFormat
-	 *            The format manager for the Format (class) asserted when a Formula is
-	 *            processed with this FormulaSemantics (may be null)
 	 * @return An initialized FormulaSemantics object with the appropriate keys set to the
 	 *         given parameters
 	 */
 	public default FormulaSemantics generateFormulaSemantics(FormulaManager manager,
-		LegalScope legalScope, FormatManager<?> assertedFormat)
+		LegalScope legalScope)
 	{
 		FormulaSemantics semantics = new FormulaSemantics();
 		semantics = semantics.getWith(FormulaSemantics.FMANAGER, manager);
-		semantics = semantics.getWith(FormulaSemantics.SCOPE, legalScope);
-		return semantics.getWith(FormulaSemantics.ASSERTED, assertedFormat);
+		return semantics.getWith(FormulaSemantics.SCOPE, legalScope);
 	}
 
 	/**
@@ -92,17 +81,13 @@ public interface ManagerFactory
 	 * @param formulaManager
 	 *            The FormulaManager used to evaluate formulas processed by this
 	 *            EvaluationManager
-	 * @param assertedFormat
-	 *            The format manager for the Format (class) asserted by the current
-	 *            context of a formula
 	 * @return A new EvaluationManager initialized with the given parameters
 	 */
 	public default EvaluationManager generateEvaluationManager(
-		FormulaManager formulaManager, FormatManager<?> assertedFormat)
+		FormulaManager formulaManager)
 	{
 		EvaluationManager manager = new EvaluationManager();
-		manager = manager.getWith(EvaluationManager.FMANAGER, formulaManager);
-		return manager.getWith(EvaluationManager.ASSERTED, assertedFormat);
+		return manager.getWith(EvaluationManager.FMANAGER, formulaManager);
 	}
 
 }

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/inst/ComplexNEPFormula.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/inst/ComplexNEPFormula.java
@@ -74,20 +74,29 @@ public class ComplexNEPFormula<T> implements NEPFormula<T>
 	private final SimpleNode root;
 
 	/**
-	 * Construct a new ComplexNEPFormula from the given String. This calculates
-	 * the tree of objects representing the calculation to be performed by the
-	 * ComplexNEPFormula, and loads the root of that tree into the root field.
+	 * The FormatManager indicating the format of the result of calculating this
+	 * ComplexNEPFormula.
+	 */
+	private final FormatManager<T> formatManager;
+
+	/**
+	 * Construct a new ComplexNEPFormula from the given String. This calculates the tree
+	 * of objects representing the calculation to be performed by the ComplexNEPFormula,
+	 * and loads the root of that tree into the root field.
 	 * 
 	 * @param expression
 	 *            The String representation of the formula used to construct the
 	 *            ComplexNEPFormula.
+	 * @param formatManager
+	 *            The FormatManager indicating the format of the result of calculating
+	 *            this ComplexNEPFormula.
 	 * @throws IllegalArgumentException
-	 *             if the given String does not represent a well-structured
-	 *             Formula. (For example, if parenthesis are not matched, an
-	 *             exception will be thrown)
+	 *             if the given String does not represent a well-structured Formula. (For
+	 *             example, if parenthesis are not matched, an exception will be thrown)
 	 */
-	public ComplexNEPFormula(String expression)
+	public ComplexNEPFormula(String expression, FormatManager<T> formatManager)
 	{
+		this.formatManager = Objects.requireNonNull(formatManager);
 		try
 		{
 			StringReader reader = new StringReader(Objects.requireNonNull(expression));
@@ -125,8 +134,10 @@ public class ComplexNEPFormula<T> implements NEPFormula<T>
 	@Override
 	public T resolve(EvaluationManager manager)
 	{
+		EvaluationManager evalManager =
+				manager.getWith(EvaluationManager.ASSERTED, formatManager);
 		@SuppressWarnings("unchecked")
-		T result = (T) EVALUATE_VISITOR.visit(root, manager);
+		T result = (T) EVALUATE_VISITOR.visit(root, evalManager);
 		return result;
 	}
 
@@ -152,8 +163,7 @@ public class ComplexNEPFormula<T> implements NEPFormula<T>
 	}
 
 	@Override
-	public void isValid(FormatManager<T> formatManager,
-		FormulaSemantics semantics)
+	public void isValid(FormulaSemantics semantics)
 	{
 		semantics.resetReport();
 		@SuppressWarnings("PMD.PrematureDeclaration")
@@ -179,5 +189,11 @@ public class ComplexNEPFormula<T> implements NEPFormula<T>
 		StringBuilder sb = new StringBuilder();
 		RECONSTRUCTION_VISITOR.visit(root, sb);
 		return sb.toString();
+	}
+
+	@Override
+	public FormatManager<T> getFormatManager()
+	{
+		return formatManager;
 	}
 }

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/inst/NEPFormula.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/inst/NEPFormula.java
@@ -63,18 +63,14 @@ public interface NEPFormula<T>
 	 * The given FormulaSemantics must contain information about variable
 	 * values, available functions, and other characteristics required for the
 	 * formula to establish the list of variables contained within the
-	 * NEPFormula. These must be valid within the context of the given
-	 * FormatManager.
+	 * NEPFormula. These must be valid within the context of the format
+	 * of the NEPFormula as returned by getFormatManager().
 	 * 
-	 * @param formatManager
-	 *            The FormatManager in which the NEPFormula should be checked to
-	 *            ensure it is valid
 	 * @param semantics
 	 *            The FormulaSemantics object used to contain and store semantic
 	 *            information about the NEPFormula
 	 */
-	public void isValid(FormatManager<T> formatManager,
-		FormulaSemantics semantics);
+	public void isValid(FormulaSemantics semantics);
 
 	/**
 	 * Determines the dependencies for this formula, including the VariableID
@@ -92,4 +88,12 @@ public interface NEPFormula<T>
 	 *            The DependencyManager to be used to capture the dependencies
 	 */
 	public void getDependencies(DependencyManager depManager);
+	
+	/**
+	 * The FormatManager in which the NEPFormula is processed (and indicating the type of
+	 * value it will return if Evaluate is called).
+	 * 
+	 * @return The FormatManager in which the NEPFormula is processed
+	 */
+	public FormatManager<T> getFormatManager();
 }

--- a/PCGen-Formula/code/src/java/pcgen/base/solver/DynamicSolverManager.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/solver/DynamicSolverManager.java
@@ -34,6 +34,7 @@ import pcgen.base.formula.base.VarScoped;
 import pcgen.base.formula.base.VariableID;
 import pcgen.base.formula.base.VariableLibrary;
 import pcgen.base.formula.base.WriteableVariableStore;
+import pcgen.base.formula.inst.NEPFormula;
 import pcgen.base.formula.inst.ScopeInstanceFactory;
 import pcgen.base.graph.inst.DefaultDirectionalGraphEdge;
 import pcgen.base.graph.inst.DirectionalSetMapGraph;
@@ -193,8 +194,9 @@ public class DynamicSolverManager implements SolverManager
 		/*
 		 * Now build new edges of things this solver will be dependent upon...
 		 */
-		DependencyManager fdm = managerFactory.generateDependencyManager(formulaManager,
-			source, varID.getFormatManager());
+		DependencyManager fdm =
+				managerFactory.generateDependencyManager(formulaManager, source);
+		fdm = fdm.getWith(DependencyManager.ASSERTED, varID.getFormatManager());
 		fdm = managerFactory.withVariables(fdm);
 		fdm = fdm.getWith(DependencyManager.DYNAMIC, new DynamicManager());
 		modifier.getDependencies(fdm);
@@ -295,8 +297,9 @@ public class DynamicSolverManager implements SolverManager
 			throw new IllegalArgumentException("Request to remove Modifier to Solver for "
 				+ varID + " but that channel was never defined");
 		}
-		DependencyManager fdm = managerFactory.generateDependencyManager(formulaManager,
-			source, varID.getFormatManager());
+		DependencyManager fdm =
+				managerFactory.generateDependencyManager(formulaManager, source);
+		fdm = fdm.getWith(DependencyManager.ASSERTED, varID.getFormatManager());
 		fdm = managerFactory.withVariables(fdm);
 		fdm = fdm.getWith(DependencyManager.DYNAMIC, new DynamicManager());
 		modifier.getDependencies(fdm);
@@ -468,8 +471,8 @@ public class DynamicSolverManager implements SolverManager
 		 * Solver should "never" be null here, so we accept risk of NPE, since it's always
 		 * a code bug
 		 */
-		EvaluationManager evalManager = managerFactory
-			.generateEvaluationManager(formulaManager, varID.getFormatManager());
+		EvaluationManager evalManager =
+				managerFactory.generateEvaluationManager(formulaManager);
 		T newValue = solver.process(evalManager);
 		Object oldValue = resultStore.put(varID, newValue);
 		return !newValue.equals(oldValue);
@@ -485,8 +488,8 @@ public class DynamicSolverManager implements SolverManager
 			throw new IllegalArgumentException("Request to diagnose VariableID " + varID
 				+ " but that channel was never defined");
 		}
-		EvaluationManager evalManager = managerFactory
-			.generateEvaluationManager(formulaManager, varID.getFormatManager());
+		EvaluationManager evalManager =
+				managerFactory.generateEvaluationManager(formulaManager);
 		return solver.diagnose(evalManager);
 	}
 
@@ -524,5 +527,13 @@ public class DynamicSolverManager implements SolverManager
 			replacement.scopedChannels.put(entry.getKey(), entry.getValue().createReplacement());
 		}
 		return replacement;
+	}
+	
+	@Override
+	public <T> T solve(NEPFormula<T> formula)
+	{
+		EvaluationManager evalManager =
+				managerFactory.generateEvaluationManager(formulaManager);
+		return formula.resolve(evalManager);
 	}
 }

--- a/PCGen-Formula/code/src/java/pcgen/base/solver/Solver.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/solver/Solver.java
@@ -188,13 +188,15 @@ public class Solver<T>
 	 */
 	public T process(EvaluationManager evalManager)
 	{
+		EvaluationManager assertedManager = evalManager
+			.getWith(EvaluationManager.ASSERTED, defaultModifier.getVariableFormat());
 		T result = defaultModifier.process(null);
 		for (Long priority : modifierList.getKeySet())
 		{
 			for (ModInfo<T> modInfo : modifierList.getListFor(priority))
 			{
 				EvaluationManager thisManager =
-						evalManager.getWith(EvaluationManager.INPUT, result);
+						assertedManager.getWith(EvaluationManager.INPUT, result);
 				thisManager = thisManager.getWith(EvaluationManager.INSTANCE,
 					modInfo.getInstance());
 				result = modInfo.getModifier().process(thisManager);
@@ -216,6 +218,8 @@ public class Solver<T>
 	 */
 	public List<ProcessStep<T>> diagnose(EvaluationManager evalManager)
 	{
+		EvaluationManager assertedManager = evalManager
+				.getWith(EvaluationManager.ASSERTED, defaultModifier.getVariableFormat());
 		List<ProcessStep<T>> steps = new ArrayList<ProcessStep<T>>();
 		T stepResult = defaultModifier.process(null);
 		steps.add(new ProcessStep<T>(defaultModifier, new DefaultValue(
@@ -227,7 +231,7 @@ public class Solver<T>
 				for (ModInfo<T> modInfo : modifierList.getListFor(priority))
 				{
 					EvaluationManager thisManager =
-							evalManager.getWith(EvaluationManager.INPUT, stepResult);
+							assertedManager.getWith(EvaluationManager.INPUT, stepResult);
 					thisManager = thisManager.getWith(EvaluationManager.INSTANCE,
 						modInfo.getInstance());
 					stepResult = modInfo.getModifier().process(thisManager);

--- a/PCGen-Formula/code/src/java/pcgen/base/solver/SolverManager.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/solver/SolverManager.java
@@ -20,6 +20,7 @@ import java.util.List;
 import pcgen.base.formula.base.ScopeInstance;
 import pcgen.base.formula.base.VariableID;
 import pcgen.base.formula.base.WriteableVariableStore;
+import pcgen.base.formula.inst.NEPFormula;
 
 /**
  * A SolverManager manages a series of Solver objects in order to manage dependencies
@@ -169,4 +170,15 @@ public interface SolverManager
 	 *         independent calculation pathways from this SolverManager
 	 */
 	public SolverManager createReplacement(WriteableVariableStore newVarStore);
+	
+	/**
+	 * Directly solves a given NEPFormula using the information in this SolverManager.
+	 * 
+	 * @param formula
+	 *            The NEPFormula to be solved using the information in this SolverManager
+	 * @return The result of evaluating the given formula based on information in this
+	 *         SolverManager
+	 */
+	public <T> T solve(NEPFormula<T> formula);
+
 }

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/AbsFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/AbsFunctionTest.java
@@ -61,7 +61,7 @@ public class AbsFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(1));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(1));
 	}
 
 	@Test
@@ -71,7 +71,7 @@ public class AbsFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(2));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(2));
 	}
 
 	@Test
@@ -81,7 +81,7 @@ public class AbsFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(6.3));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(6.3));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -94,7 +94,7 @@ public class AbsFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(5.3));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(5.3));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -107,7 +107,7 @@ public class AbsFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(5.3));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(5.3));
 	}
 
 	@Test
@@ -117,7 +117,7 @@ public class AbsFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(5.3));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(5.3));
 	}
 
 	@Test
@@ -127,7 +127,7 @@ public class AbsFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(5.3));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(5.3));
 		List<VariableID<?>> vars = getVariables(node);
 		assertEquals(0, vars.size());
 	}

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/CeilFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/CeilFunctionTest.java
@@ -61,7 +61,7 @@ public class CeilFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(1));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(1));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -74,7 +74,7 @@ public class CeilFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(-2));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-2));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -87,7 +87,7 @@ public class CeilFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(7));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(7));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -100,7 +100,7 @@ public class CeilFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(-5));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-5));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -113,7 +113,7 @@ public class CeilFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(-5));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-5));
 	}
 
 	@Test
@@ -123,7 +123,7 @@ public class CeilFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(-5));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-5));
 	}
 
 	@Test
@@ -133,7 +133,7 @@ public class CeilFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(-5));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-5));
 	}
 	
 	@Test

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/FloorFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/FloorFunctionTest.java
@@ -61,7 +61,7 @@ public class FloorFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(1));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(1));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -74,7 +74,7 @@ public class FloorFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(-2));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-2));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -87,7 +87,7 @@ public class FloorFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(6));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(6));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -100,7 +100,7 @@ public class FloorFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(-6));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-6));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -113,7 +113,7 @@ public class FloorFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(-6));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-6));
 	}
 
 	@Test
@@ -123,7 +123,7 @@ public class FloorFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(-6));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-6));
 	}
 
 	@Test
@@ -133,7 +133,7 @@ public class FloorFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(-6));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-6));
 	}
 
 	@Test

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/IfFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/IfFunctionTest.java
@@ -92,7 +92,7 @@ public class IfFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(2));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(2));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -105,7 +105,7 @@ public class IfFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(3));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(3));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -118,7 +118,7 @@ public class IfFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(7.8));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(7.8));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -131,7 +131,7 @@ public class IfFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(-3.4));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-3.4));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -144,7 +144,7 @@ public class IfFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(-3.3));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-3.3));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -157,7 +157,7 @@ public class IfFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(-3.3));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-3.3));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -170,7 +170,7 @@ public class IfFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(-3.3));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-3.3));
 	}
 
 	@Test
@@ -180,7 +180,7 @@ public class IfFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(-3.3));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-3.3));
 	}
 
 	@Test
@@ -190,7 +190,7 @@ public class IfFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(-3.3));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-3.3));
 	}
 
 	@Test
@@ -200,7 +200,7 @@ public class IfFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(-3.3));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-3.3));
 		List<VariableID<?>> vars = getVariables(node);
 		assertEquals(0, vars.size());
 	}
@@ -213,7 +213,7 @@ public class IfFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, false);
-		evaluatesTo(formula, node, Integer.valueOf(5));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(5));
 		List<VariableID<?>> vars = getVariables(node);
 		assertEquals(1, vars.size());
 		VariableID<?> var = vars.get(0);
@@ -231,7 +231,7 @@ public class IfFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, false);
-		evaluatesTo(formula, node, Integer.valueOf(3));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(3));
 		List<VariableID<?>> vars = getVariables(node);
 		assertEquals(3, vars.size());
 		Set<String> set = new HashSet<String>();

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/MaxFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/MaxFunctionTest.java
@@ -69,7 +69,7 @@ public class MaxFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(2));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(2));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -82,7 +82,7 @@ public class MaxFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(3));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(3));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -95,7 +95,7 @@ public class MaxFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(7.8));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(7.8));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -108,7 +108,7 @@ public class MaxFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(-3.4));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-3.4));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -121,7 +121,7 @@ public class MaxFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(8.3));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(8.3));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -134,7 +134,7 @@ public class MaxFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(8.2));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(8.2));
 	}
 
 	@Test
@@ -144,7 +144,7 @@ public class MaxFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(8.2));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(8.2));
 	}
 
 	@Test
@@ -154,7 +154,7 @@ public class MaxFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(8.4));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(8.4));
 	}
 
 	@Test
@@ -164,7 +164,7 @@ public class MaxFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(8.11));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(8.11));
 		List<VariableID<?>> vars = getVariables(node);
 		assertEquals(0, vars.size());
 	}
@@ -177,7 +177,7 @@ public class MaxFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, false);
-		evaluatesTo(formula, node, Integer.valueOf(5));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(5));
 		List<VariableID<?>> vars = getVariables(node);
 		assertEquals(1, vars.size());
 		VariableID<?> var = vars.get(0);

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/MinFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/MinFunctionTest.java
@@ -61,7 +61,7 @@ public class MinFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(1));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(1));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -74,7 +74,7 @@ public class MinFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(-2));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-2));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -87,7 +87,7 @@ public class MinFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(3.3));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(3.3));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -100,7 +100,7 @@ public class MinFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(-3.4));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-3.4));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -113,7 +113,7 @@ public class MinFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(-3.3));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-3.3));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -126,7 +126,7 @@ public class MinFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(-3.3));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-3.3));
 	}
 
 	@Test
@@ -136,7 +136,7 @@ public class MinFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(-3.3));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-3.3));
 	}
 
 	@Test
@@ -146,7 +146,7 @@ public class MinFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(-3.3));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-3.3));
 	}
 
 	@Test
@@ -156,7 +156,7 @@ public class MinFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Double.valueOf(-3.3));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-3.3));
 	}
 
 	@Test

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/RoundFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/RoundFunctionTest.java
@@ -61,7 +61,7 @@ public class RoundFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(1));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(1));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -74,7 +74,7 @@ public class RoundFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(-2));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-2));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -87,7 +87,7 @@ public class RoundFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(6));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(6));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -100,7 +100,7 @@ public class RoundFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(7));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(7));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -113,7 +113,7 @@ public class RoundFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(-6));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-6));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -126,7 +126,7 @@ public class RoundFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(-5));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-5));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -139,7 +139,7 @@ public class RoundFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(-5));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-5));
 	}
 
 	@Test
@@ -149,7 +149,7 @@ public class RoundFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(-5));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-5));
 	}
 
 	@Test
@@ -159,7 +159,7 @@ public class RoundFunctionTest extends AbstractFormulaTestCase
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
-		evaluatesTo(formula, node, Integer.valueOf(-5));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-5));
 	}
 
 	@Test

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/ValueFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/ValueFunctionTest.java
@@ -44,7 +44,7 @@ public class ValueFunctionTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, false);
 		EvaluationManager manager = generateManager().getWith(EvaluationManager.INPUT, 1);
-		performEvaluation(formula, node, Integer.valueOf(1), manager);
+		performEvaluation(numberManager, formula, node, Integer.valueOf(1), manager);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/ComplexNEPFormulaTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/ComplexNEPFormulaTest.java
@@ -31,7 +31,7 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 	{
 		try
 		{
-			new ComplexNEPFormula<>(null);
+			new ComplexNEPFormula<>(null, numberMgr);
 			fail("Expected null formula text to fail");
 		}
 		catch (IllegalArgumentException | NullPointerException e)
@@ -40,7 +40,16 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 		}
 		try
 		{
-			new ComplexNEPFormula<>("3+*5");
+			new ComplexNEPFormula<>("3+6", null);
+			fail("Expected null format manager to fail");
+		}
+		catch (IllegalArgumentException | NullPointerException e)
+		{
+			//ok
+		}
+		try
+		{
+			new ComplexNEPFormula<>("3+*5", numberMgr);
 			fail("Expected bad formula text to fail");
 		}
 		catch (IllegalArgumentException e)
@@ -51,19 +60,20 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 
 	public void testToString()
 	{
-		assertEquals("3+5", new ComplexNEPFormula<>("3+5").toString());
-		assertEquals("3*5", new ComplexNEPFormula<>("3*5").toString());
-		assertEquals("(3+5)*7", new ComplexNEPFormula<>("(3+5)*7").toString());
-		assertEquals("a-b", new ComplexNEPFormula<>("a-b").toString());
-		assertEquals("if(a>=b,5,9)", new ComplexNEPFormula<>("if(a>=b,5,9)").toString());
+		assertEquals("3+5", new ComplexNEPFormula<>("3+5", numberMgr).toString());
+		assertEquals("3*5", new ComplexNEPFormula<>("3*5", numberMgr).toString());
+		assertEquals("(3+5)*7", new ComplexNEPFormula<>("(3+5)*7", numberMgr).toString());
+		assertEquals("a-b", new ComplexNEPFormula<>("a-b", numberMgr).toString());
+		assertEquals("if(a>=b,5,9)",
+			new ComplexNEPFormula<>("if(a>=b,5,9)", numberMgr).toString());
 		assertEquals("if(a==b,5,-9)",
-			new ComplexNEPFormula<>("if(a==b,5,-9)").toString());
+			new ComplexNEPFormula<>("if(a==b,5,-9)", numberMgr).toString());
 		assertEquals("if(a||b,\"A\",\"B\")",
-			new ComplexNEPFormula<>("if(a||b,\"A\",\"B\")").toString());
-		assertEquals("value()", new ComplexNEPFormula<>("value()").toString());
-		assertEquals("3^5", new ComplexNEPFormula<>("3^5").toString());
+			new ComplexNEPFormula<>("if(a||b,\"A\",\"B\")", numberMgr).toString());
+		assertEquals("value()", new ComplexNEPFormula<>("value()", numberMgr).toString());
+		assertEquals("3^5", new ComplexNEPFormula<>("3^5", numberMgr).toString());
 		assertEquals("process[THIS]",
-			new ComplexNEPFormula<>("process[THIS]").toString());
+			new ComplexNEPFormula<>("process[THIS]", numberMgr).toString());
 	}
 
 	public void testIsValid()
@@ -71,48 +81,39 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 		FormulaSemantics fs = getSemantics();
 		try
 		{
-			new ComplexNEPFormula<Number>("3+5").isValid(numberMgr, null);
+			new ComplexNEPFormula<Number>("3+5", numberMgr).isValid(null);
 			fail("Expected null FormulaSemantics to fail");
 		}
 		catch (IllegalArgumentException | NullPointerException e)
 		{
 			//ok
 		}
-		try
-		{
-			new ComplexNEPFormula<>("3+5").isValid(null, fs);
-			fail("Expected null FormatManager to fail");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
 
-		new ComplexNEPFormula<Number>("3+5").isValid(numberMgr, fs);
+		new ComplexNEPFormula<Number>("3+5", numberMgr).isValid(fs);
 		assertEquals(true, fs.isValid());
-		new ComplexNEPFormula<Number>("3*5").isValid(numberMgr, fs);
+		new ComplexNEPFormula<Number>("3*5", numberMgr).isValid(fs);
 		assertEquals(true, fs.isValid());
-		new ComplexNEPFormula<Number>("(3+5)*7").isValid(numberMgr, fs);
+		new ComplexNEPFormula<Number>("(3+5)*7", numberMgr).isValid(fs);
 		assertEquals(true, fs.isValid());
 
 		getVariableLibrary().assertLegalVariableID("a", getGlobalScope(), numberMgr);
 		getVariableLibrary().assertLegalVariableID("b", getGlobalScope(), numberMgr);
-		new ComplexNEPFormula<Number>("a-b").isValid(numberMgr, fs);
+		new ComplexNEPFormula<Number>("a-b", numberMgr).isValid(fs);
 		assertEquals(true, fs.isValid());
-		new ComplexNEPFormula<Number>("if(a>=b,5,9)").isValid(numberMgr, fs);
+		new ComplexNEPFormula<Number>("if(a>=b,5,9)", numberMgr).isValid(fs);
 		assertEquals(true, fs.isValid());
-		new ComplexNEPFormula<Number>("if(a==b,5,-9)").isValid(numberMgr, fs);
+		new ComplexNEPFormula<Number>("if(a==b,5,-9)", numberMgr).isValid(fs);
 		assertEquals(true, fs.isValid());
 
 		getVariableLibrary().assertLegalVariableID("c", getGlobalScope(), booleanMgr);
 		getVariableLibrary().assertLegalVariableID("d", getGlobalScope(), booleanMgr);
-		new ComplexNEPFormula<String>("if(c||d,\"A\",\"B\")").isValid(stringMgr, fs);
+		new ComplexNEPFormula<String>("if(c||d,\"A\",\"B\")", stringMgr).isValid(fs);
 		assertEquals(true, fs.isValid());
 
-		new ComplexNEPFormula<Number>("value()").isValid(numberMgr,
-			fs.getWith(FormulaSemantics.INPUT_FORMAT, numberMgr));
+		new ComplexNEPFormula<Number>("value()", numberMgr)
+			.isValid(fs.getWith(FormulaSemantics.INPUT_FORMAT, numberMgr));
 		assertEquals(true, fs.isValid());
-		new ComplexNEPFormula<Number>("3^5").isValid(numberMgr, fs);
+		new ComplexNEPFormula<Number>("3^5", numberMgr).isValid(fs);
 		assertEquals(true, fs.isValid());
 	}
 
@@ -120,19 +121,19 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 	{
 		DependencyManager depManager = setupDM();
 
-		new ComplexNEPFormula<>("3+5").getDependencies(depManager);
+		new ComplexNEPFormula<>("3+5", numberMgr).getDependencies(depManager);
 		assertTrue(depManager.get(DependencyManager.VARIABLES).getVariables().isEmpty());
 		assertEquals(-1,
 			depManager.get(ArgumentDependencyManager.KEY).getMaximumArgument());
 
 		depManager = setupDM();
-		new ComplexNEPFormula<>("3*5").getDependencies(depManager);
+		new ComplexNEPFormula<>("3*5", numberMgr).getDependencies(depManager);
 		assertTrue(depManager.get(DependencyManager.VARIABLES).getVariables().isEmpty());
 		assertEquals(-1,
 			depManager.get(ArgumentDependencyManager.KEY).getMaximumArgument());
 
 		depManager = setupDM();
-		new ComplexNEPFormula<>("(3+5)*7").getDependencies(depManager);
+		new ComplexNEPFormula<>("(3+5)*7", numberMgr).getDependencies(depManager);
 		assertTrue(depManager.get(DependencyManager.VARIABLES).getVariables().isEmpty());
 		assertEquals(-1,
 			depManager.get(ArgumentDependencyManager.KEY).getMaximumArgument());
@@ -141,8 +142,9 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 		getVariableLibrary().assertLegalVariableID("b", getGlobalScope(), numberMgr);
 
 		depManager = setupDM();
-		new ComplexNEPFormula<>("a-b").getDependencies(depManager);
-		List<VariableID<?>> variables = depManager.get(DependencyManager.VARIABLES).getVariables();
+		new ComplexNEPFormula<>("a-b", numberMgr).getDependencies(depManager);
+		List<VariableID<?>> variables =
+				depManager.get(DependencyManager.VARIABLES).getVariables();
 		assertEquals(2, variables.size());
 		assertTrue(
 			variables.contains(new VariableID<>(getGlobalScopeInst(), numberMgr, "a")));
@@ -152,7 +154,7 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 			depManager.get(ArgumentDependencyManager.KEY).getMaximumArgument());
 
 		depManager = setupDM();
-		new ComplexNEPFormula<>("if(a>=b,5,9)").getDependencies(depManager);
+		new ComplexNEPFormula<>("if(a>=b,5,9)", numberMgr).getDependencies(depManager);
 		variables = depManager.get(DependencyManager.VARIABLES).getVariables();
 		assertEquals(2, variables.size());
 		assertTrue(
@@ -163,7 +165,7 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 			depManager.get(ArgumentDependencyManager.KEY).getMaximumArgument());
 
 		depManager = setupDM();
-		new ComplexNEPFormula<>("if(a==b,5,-9)").getDependencies(depManager);
+		new ComplexNEPFormula<>("if(a==b,5,-9)", numberMgr).getDependencies(depManager);
 		variables = depManager.get(DependencyManager.VARIABLES).getVariables();
 		assertEquals(2, variables.size());
 		assertTrue(
@@ -177,7 +179,7 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 		getVariableLibrary().assertLegalVariableID("d", getGlobalScope(), booleanMgr);
 
 		depManager = setupDM();
-		new ComplexNEPFormula<>("if(c||d,\"A\",\"B\")").getDependencies(depManager);
+		new ComplexNEPFormula<>("if(c||d,\"A\",\"B\")", stringMgr).getDependencies(depManager);
 		variables = depManager.get(DependencyManager.VARIABLES).getVariables();
 		assertEquals(2, variables.size());
 		assertTrue(
@@ -188,14 +190,14 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 			depManager.get(ArgumentDependencyManager.KEY).getMaximumArgument());
 
 		depManager = setupDM();
-		new ComplexNEPFormula<>("value()").getDependencies(
+		new ComplexNEPFormula<>("value()", numberMgr).getDependencies(
 			depManager.getWith(DependencyManager.INPUT_FORMAT, numberManager));
 		assertTrue(depManager.get(DependencyManager.VARIABLES).getVariables().isEmpty());
 		assertEquals(-1,
 			depManager.get(ArgumentDependencyManager.KEY).getMaximumArgument());
 
 		depManager = setupDM();
-		new ComplexNEPFormula<>("3^5").getDependencies(depManager);
+		new ComplexNEPFormula<>("3^5", numberMgr).getDependencies(depManager);
 		assertTrue(depManager.get(DependencyManager.VARIABLES).getVariables().isEmpty());
 		assertEquals(-1,
 			depManager.get(ArgumentDependencyManager.KEY).getMaximumArgument());
@@ -204,7 +206,7 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 	private DependencyManager setupDM()
 	{
 		DependencyManager dm = managerFactory
-			.generateDependencyManager(getFormulaManager(), getGlobalScopeInst(), null);
+			.generateDependencyManager(getFormulaManager(), getGlobalScopeInst());
 		dm = managerFactory.withVariables(dm);
 		return dm.getWith(ArgumentDependencyManager.KEY, new ArgumentDependencyManager());
 	}
@@ -214,7 +216,7 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 		EvaluationManager evalManager = generateManager();
 		try
 		{
-			new ComplexNEPFormula<>("3+5").resolve(null);
+			new ComplexNEPFormula<>("3+5", numberMgr).resolve(null);
 			fail("Expected null FormulaManager to fail");
 		}
 		catch (IllegalArgumentException | NullPointerException e)
@@ -222,20 +224,23 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 			//ok
 		}
 
-		assertEquals(8, new ComplexNEPFormula<>("3+5").resolve(evalManager));
-		assertEquals(15, new ComplexNEPFormula<>("3*5").resolve(evalManager));
-		assertEquals(56, new ComplexNEPFormula<>("(3+5)*7").resolve(evalManager));
+		assertEquals(8, new ComplexNEPFormula<>("3+5", numberMgr).resolve(evalManager));
+		assertEquals(15, new ComplexNEPFormula<>("3*5", numberMgr).resolve(evalManager));
+		assertEquals(56,
+			new ComplexNEPFormula<>("(3+5)*7", numberMgr).resolve(evalManager));
 
 		getVariableLibrary().assertLegalVariableID("a", getGlobalScope(), numberMgr);
 		getVariableLibrary().assertLegalVariableID("b", getGlobalScope(), numberMgr);
 
 		getVariableStore().put(new VariableID<>(getGlobalScopeInst(), numberMgr, "a"), 4);
 		getVariableStore().put(new VariableID<>(getGlobalScopeInst(), numberMgr, "b"), 1);
-		assertEquals(3, new ComplexNEPFormula<>("a-b").resolve(evalManager));
+		assertEquals(3, new ComplexNEPFormula<>("a-b", numberMgr).resolve(evalManager));
 
-		assertEquals(5, new ComplexNEPFormula<>("if(a>=b,5,9)").resolve(evalManager));
+		assertEquals(5,
+			new ComplexNEPFormula<>("if(a>=b,5,9)", numberMgr).resolve(evalManager));
 
-		assertEquals(-9, new ComplexNEPFormula<>("if(a==b,5,-9)").resolve(evalManager));
+		assertEquals(-9,
+			new ComplexNEPFormula<>("if(a==b,5,-9)", numberMgr).resolve(evalManager));
 
 		getVariableLibrary().assertLegalVariableID("c", getGlobalScope(), booleanMgr);
 		getVariableLibrary().assertLegalVariableID("d", getGlobalScope(), booleanMgr);
@@ -245,49 +250,49 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 			true);
 
 		assertEquals("A",
-			new ComplexNEPFormula<>("if(c||d,\"A\",\"B\")").resolve(evalManager));
+			new ComplexNEPFormula<>("if(c||d,\"A\",\"B\")", numberMgr).resolve(evalManager));
 
 		EvaluationManager manager = this.generateManager(4);
-		assertEquals(4, new ComplexNEPFormula<>("value()").resolve(manager));
-		assertEquals(243.0, new ComplexNEPFormula<>("3^5").resolve(evalManager));
+		assertEquals(4, new ComplexNEPFormula<>("value()", numberMgr).resolve(manager));
+		assertEquals(243.0, new ComplexNEPFormula<>("3^5", numberMgr).resolve(evalManager));
 	}
-	
 
 	@Test
 	public void testAssertion()
 	{
-		ComplexNEPFormula five = new ComplexNEPFormula("5");
-		ComplexNEPFormula fiveString = new ComplexNEPFormula("\"4\"");
-		ComplexNEPFormula notANumber = new ComplexNEPFormula("\"4,4\"");
+		ComplexNEPFormula five = new ComplexNEPFormula("5", numberMgr);
+		ComplexNEPFormula fiveMismatch = new ComplexNEPFormula("5", stringMgr);
+		ComplexNEPFormula longWayAround = new ComplexNEPFormula("\"4\"", numberMgr);
+		ComplexNEPFormula fiveString = new ComplexNEPFormula("\"4\"", stringMgr);
+		ComplexNEPFormula notANumber = new ComplexNEPFormula("\"4,4\"", numberMgr);
 
 		FormulaSemantics fs = getSemantics();
-		five.isValid(numberMgr, fs);
+		five.isValid(fs);
 		assertEquals(true, fs.isValid());
 
-		five.isValid(stringMgr, fs);
+		fiveMismatch.isValid(fs);
 		assertEquals(false, fs.isValid());
 
-		fiveString.isValid(numberMgr, fs);
-		assertEquals(false, fs.isValid());
-
-		fiveString.isValid(stringMgr, fs);
-		//Note this implicitly tests that isValid is resetting the report
+		fiveString.isValid(fs);
 		assertEquals(true, fs.isValid());
-		
-		fiveString.isValid(numberMgr, fs.getWith(FormulaSemantics.ASSERTED, numberMgr));
+
+		longWayAround.isValid(fs);
+		assertEquals(false, fs.isValid());
+
+		longWayAround.isValid(fs.getWith(FormulaSemantics.ASSERTED, numberMgr));
 		//Note this implicitly tests that the report survives the .getWith
 		assertEquals(true, fs.isValid());
 
-		fiveString.isValid(stringMgr, fs.getWith(FormulaSemantics.ASSERTED, numberMgr));
+		fiveString.isValid(fs.getWith(FormulaSemantics.ASSERTED, numberMgr));
 		assertEquals(false, fs.isValid());
 
-		notANumber.isValid(numberMgr, fs.getWith(FormulaSemantics.ASSERTED, numberMgr));
+		notANumber.isValid(fs.getWith(FormulaSemantics.ASSERTED, numberMgr));
 		assertEquals(false, fs.isValid());
 	}
 
 	private FormulaSemantics getSemantics()
 	{
 		return managerFactory.generateFormulaSemantics(getFormulaManager(),
-			getGlobalScope(), null);
+			getGlobalScope());
 	}
 }

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/library/ArgFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/library/ArgFunctionTest.java
@@ -57,7 +57,7 @@ public class ArgFunctionTest extends AbstractFormulaTestCase
 	private void resetManager()
 	{
 		depManager = getManagerFactory().generateDependencyManager(getFormulaManager(),
-			getGlobalScopeInst(), null);
+			getGlobalScopeInst());
 		depManager = getManagerFactory().withVariables(depManager);
 		argManager = new ArgumentDependencyManager();
 		depManager = depManager.getWith(ArgumentDependencyManager.KEY, argManager);
@@ -83,7 +83,7 @@ public class ArgFunctionTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		varCapture.visit(node, null);
 		assertEquals(-1, argManager.getMaximumArgument());
-		evaluatesTo(formula, node, Integer.valueOf(4));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(4));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -130,7 +130,7 @@ public class ArgFunctionTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		varCapture.visit(node, depManager);
 		assertEquals(0, argManager.getMaximumArgument());
-		evaluatesTo(formula, node, Integer.valueOf(4));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(4));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -145,13 +145,13 @@ public class ArgFunctionTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		varCapture.visit(node, depManager);
 		assertEquals(1, argManager.getMaximumArgument());
-		evaluatesTo(formula, node, Integer.valueOf(5));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(5));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
 		DependencyManager fdm =
 				getManagerFactory().generateDependencyManager(getFormulaManager(),
-					getGlobalScopeInst(), null);
+					getGlobalScopeInst());
 		fdm = getManagerFactory().withVariables(fdm);
 		/*
 		 * Safe and "ignored" - if this test fails, need to change what FDM is
@@ -171,7 +171,7 @@ public class ArgFunctionTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		varCapture.visit(node, depManager);
 		assertEquals(2, argManager.getMaximumArgument());
-		evaluatesTo(formula, node, Double.valueOf(4.5));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(4.5));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/library/GenericFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/library/GenericFunctionTest.java
@@ -49,7 +49,7 @@ public class GenericFunctionTest extends AbstractFormulaTestCase
 	private void resetManager()
 	{
 		depManager = getManagerFactory().generateDependencyManager(getFormulaManager(),
-			getGlobalScopeInst(), null);
+			getGlobalScopeInst());
 		depManager = getManagerFactory().withVariables(depManager);
 		argManager = new ArgumentDependencyManager();
 		depManager = depManager.getWith(ArgumentDependencyManager.KEY, argManager);
@@ -85,7 +85,7 @@ public class GenericFunctionTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		varCapture.visit(node, depManager);
 		assertEquals(-1, argManager.getMaximumArgument());
-		evaluatesTo(formula, node, Integer.valueOf(2));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(2));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -111,7 +111,7 @@ public class GenericFunctionTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		varCapture.visit(node, depManager);
 		assertEquals(0, argManager.getMaximumArgument());
-		evaluatesTo(formula, node, Integer.valueOf(2));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(2));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -129,7 +129,7 @@ public class GenericFunctionTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		varCapture.visit(node, depManager);
 		assertEquals(0, argManager.getMaximumArgument());
-		evaluatesTo(formula, node, Integer.valueOf(3));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(3));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -150,7 +150,7 @@ public class GenericFunctionTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		varCapture.visit(node, depManager);
 		assertEquals(1, argManager.getMaximumArgument());
-		evaluatesTo(formula, node, Integer.valueOf(-4));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-4));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -171,7 +171,7 @@ public class GenericFunctionTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		varCapture.visit(node, depManager);
 		assertEquals(1, argManager.getMaximumArgument());
-		evaluatesTo(formula, node, Integer.valueOf(6));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(6));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/parse/FormulaArithmeticTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/parse/FormulaArithmeticTest.java
@@ -47,7 +47,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Integer.valueOf(1));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(1));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -61,7 +61,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Integer.valueOf(0));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(0));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -75,7 +75,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Integer.valueOf(-5));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-5));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -89,7 +89,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(1.0));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(1.0));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -103,7 +103,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(1.1));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(1.1));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -117,7 +117,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-4.5));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-4.5));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -131,7 +131,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-0.5));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-0.5));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -145,7 +145,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(0.2));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(0.2));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -160,7 +160,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Integer.valueOf(5));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(5));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -174,7 +174,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(5.2));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(5.2));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -188,7 +188,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(5.1));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(5.1));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -202,7 +202,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(5.5));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(5.5));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -217,7 +217,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Integer.valueOf(-1));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-1));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -231,7 +231,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-1.2));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-1.2));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -245,7 +245,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-0.9));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-0.9));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -259,7 +259,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-1.3));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-1.3));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -274,7 +274,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Integer.valueOf(1));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(1));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -288,7 +288,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(1.2));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(1.2));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -302,7 +302,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(0.9));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(0.9));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -316,7 +316,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(1.3));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(1.3));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -330,7 +330,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Integer.valueOf(12));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(12));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -344,7 +344,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(12.1));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(12.1));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -358,7 +358,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(12.2));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(12.2));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -373,7 +373,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note this is a Double
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(0));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(0));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -388,7 +388,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Integer.valueOf(-1));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-1));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -402,7 +402,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-1.2));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-1.2));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -416,7 +416,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-0.9));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-0.9));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -430,7 +430,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-1.3));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-1.3));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -445,7 +445,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Integer.valueOf(5));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(5));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -459,7 +459,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(5.2));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(5.2));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -473,7 +473,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(5.1));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(5.1));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -487,7 +487,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(5.5));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(5.5));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -502,7 +502,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Integer.valueOf(-5));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-5));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -516,7 +516,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-5.2));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-5.2));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -530,7 +530,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-5.1));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-5.1));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -544,7 +544,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-5.5));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-5.5));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -558,7 +558,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Integer.valueOf(-10));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-10));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -572,7 +572,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-10.1));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-10.1));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -586,7 +586,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-10.2));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-10.2));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -601,7 +601,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -615,7 +615,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -629,7 +629,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -643,7 +643,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -658,7 +658,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -672,7 +672,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -686,7 +686,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -700,7 +700,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -715,7 +715,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -729,7 +729,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -743,7 +743,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -757,7 +757,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -771,7 +771,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -785,7 +785,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -799,7 +799,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -813,7 +813,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -827,7 +827,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -841,7 +841,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -856,7 +856,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -870,7 +870,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -884,7 +884,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -898,7 +898,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -913,7 +913,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -927,7 +927,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -941,7 +941,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -955,7 +955,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -970,7 +970,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -984,7 +984,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -998,7 +998,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1012,7 +1012,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1026,7 +1026,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1040,7 +1040,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1054,7 +1054,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1068,7 +1068,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1082,7 +1082,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1096,7 +1096,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1111,7 +1111,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1125,7 +1125,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1139,7 +1139,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1153,7 +1153,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1168,7 +1168,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1182,7 +1182,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1196,7 +1196,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1210,7 +1210,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1225,7 +1225,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1239,7 +1239,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1253,7 +1253,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1267,7 +1267,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1281,7 +1281,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1295,7 +1295,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1309,7 +1309,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1323,7 +1323,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1337,7 +1337,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1351,7 +1351,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1366,7 +1366,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1380,7 +1380,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1394,7 +1394,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1408,7 +1408,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1423,7 +1423,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1437,7 +1437,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1451,7 +1451,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1465,7 +1465,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1480,7 +1480,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1494,7 +1494,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1508,7 +1508,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1522,7 +1522,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1536,7 +1536,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1550,7 +1550,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1564,7 +1564,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1578,7 +1578,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1592,7 +1592,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1606,7 +1606,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1621,7 +1621,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1635,7 +1635,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1649,7 +1649,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1663,7 +1663,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1678,7 +1678,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1692,7 +1692,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1706,7 +1706,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1720,7 +1720,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1735,7 +1735,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1749,7 +1749,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1763,7 +1763,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1777,7 +1777,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1791,7 +1791,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1805,7 +1805,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1819,7 +1819,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1833,7 +1833,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1847,7 +1847,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1861,7 +1861,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1876,7 +1876,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1890,7 +1890,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1904,7 +1904,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1918,7 +1918,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1933,7 +1933,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1947,7 +1947,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1961,7 +1961,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1975,7 +1975,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1990,7 +1990,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2004,7 +2004,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2018,7 +2018,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2032,7 +2032,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2046,7 +2046,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2060,7 +2060,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2074,7 +2074,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2088,7 +2088,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2102,7 +2102,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2116,7 +2116,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, booleanManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2131,7 +2131,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Integer.valueOf(6));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(6));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2145,7 +2145,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(6.4));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(6.4));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2159,7 +2159,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(6.3));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(6.3));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2173,7 +2173,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(7.14));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(7.14));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2188,7 +2188,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Integer.valueOf(-6));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-6));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2202,7 +2202,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-6.4));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-6.4));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2216,7 +2216,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-6.3));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-6.3));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2230,7 +2230,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-7.14));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-7.14));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2245,7 +2245,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Integer.valueOf(-6));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-6));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2259,7 +2259,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-6.4));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-6.4));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2273,7 +2273,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-6.3));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-6.3));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2287,7 +2287,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-7.14));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-7.14));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2301,7 +2301,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Integer.valueOf(28));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(28));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2315,7 +2315,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(28.7));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(28.7));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2329,7 +2329,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(28.8));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(28.8));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2344,7 +2344,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Don't expect a test for Integer == Zero, Double return is OK
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Integer.valueOf(0));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(0));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2359,7 +2359,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(2.0 / 3.0));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(2.0 / 3.0));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2373,7 +2373,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(0.625));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(0.625));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2387,7 +2387,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(0.7));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(0.7));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2401,7 +2401,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(2.1 / 3.4));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(2.1 / 3.4));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2416,7 +2416,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-0.25));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-0.25));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2430,7 +2430,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-0.625));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-0.625));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2444,7 +2444,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-0.7));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-0.7));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2458,7 +2458,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(2.1 / -3.4));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(2.1 / -3.4));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2473,7 +2473,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-2.0 / 3.0));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-2.0 / 3.0));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2487,7 +2487,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-0.625));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-0.625));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2501,7 +2501,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-0.7));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-0.7));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2515,7 +2515,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-2.1 / 3.4));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-2.1 / 3.4));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2529,7 +2529,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(1.0 / 4.0 / 7.0));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(1.0 / 4.0 / 7.0));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2543,7 +2543,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(1 / 4.1 / 7));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(1 / 4.1 / 7));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2557,7 +2557,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(1.0 / 4.0 / 7.2));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(1.0 / 4.0 / 7.2));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2572,7 +2572,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Don't expect a test for Numerator == Integer Zero, Double return is OK
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(0.0));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(0.0));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2586,7 +2586,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(Double.POSITIVE_INFINITY));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(Double.POSITIVE_INFINITY));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2601,7 +2601,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Integer.valueOf(2));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(2));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2615,7 +2615,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(2.0));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(2.0));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2629,7 +2629,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(1.1));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(1.1));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2643,7 +2643,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(2.1));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(2.1));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2658,7 +2658,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Integer.valueOf(2));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(2));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2672,7 +2672,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(2.0));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(2.0));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2686,7 +2686,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(2.1));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(2.1));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2700,7 +2700,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(2.1));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(2.1));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2715,7 +2715,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Integer.valueOf(-2));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-2));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2729,7 +2729,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-2.0));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-2.0));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2743,7 +2743,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-2.1));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-2.1));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2757,7 +2757,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-2.1));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-2.1));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2771,7 +2771,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Integer.valueOf(1));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(1));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2785,7 +2785,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(0.8));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(0.8));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2799,7 +2799,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(0.6));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(0.6));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2814,7 +2814,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Don't expect a test for Numerator == Integer Zero, Double return is OK
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(0.0));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(0.0));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2828,7 +2828,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(Double.NaN));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(Double.NaN));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2844,7 +2844,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
 		//Note expectation setting here - NOT integer math
-		evaluatesTo(formula, node, Double.valueOf(8));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(8));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2858,7 +2858,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(Math.pow(2.0, 3.2)));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(Math.pow(2.0, 3.2)));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2872,7 +2872,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(9.261));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(9.261));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2886,7 +2886,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(Math.pow(2.1, 3.4)));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(Math.pow(2.1, 3.4)));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2902,7 +2902,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
 		//Note expectation setting here - NOT integer math
-		evaluatesTo(formula, node, Double.valueOf(-8));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-8));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2916,7 +2916,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-Math.pow(2.0, 3.2)));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-Math.pow(2.0, 3.2)));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2930,7 +2930,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-9.261));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-9.261));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2944,7 +2944,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(-Math.pow(2.1, 3.4)));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-Math.pow(2.1, 3.4)));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2958,7 +2958,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(Math.pow(1.03, 28)));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(Math.pow(1.03, 28)));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2972,7 +2972,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(Math.pow(1.03, 28.7)));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(Math.pow(1.03, 28.7)));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2986,7 +2986,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(Math.pow(1.03, 28.8)));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(Math.pow(1.03, 28.8)));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -3001,7 +3001,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Don't expect a test for Numerator == Integer Zero, Double return is OK
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(0.0));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(0.0));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -3016,7 +3016,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isStatic(formula, node, true);
 		//Don't expect a test for Power == Integer Zero, Double return is OK
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(1.0));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(1.0));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -3030,7 +3030,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Integer.valueOf(9));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(9));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -3044,7 +3044,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(formula, node, Double.valueOf(2));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(2));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/parse/FormulaVariableTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/parse/FormulaVariableTest.java
@@ -71,7 +71,7 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 		VariableID<?> var0 = vars.get(0);
 		assertEquals("a", var0.getName());
 		assertEquals(getGlobalScopeInst(), var0.getScope());
-		evaluatesTo(formula, node, Integer.valueOf(5));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(5));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -90,7 +90,7 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 		VariableID<?> var0 = vars.get(0);
 		assertEquals("a", var0.getName());
 		assertEquals(getGlobalScopeInst(), var0.getScope());
-		evaluatesTo(formula, node, Integer.valueOf(-7));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(-7));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -109,7 +109,7 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 		VariableID<?> var0 = vars.get(0);
 		assertEquals("a", var0.getName());
 		assertEquals(getGlobalScopeInst(), var0.getScope());
-		evaluatesTo(formula, node, Double.valueOf(-7.3));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-7.3));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -126,7 +126,7 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 		isStatic(formula, node, false);
 		hasABVars(formula, node);
 		//Note integer math
-		evaluatesTo(formula, node, Integer.valueOf(10));
+		evaluatesTo(numberManager, formula, node, Integer.valueOf(10));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -143,7 +143,7 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 		isStatic(formula, node, false);
 		hasABVars(formula, node);
 		//Note integer math
-		evaluatesTo(formula, node, Double.valueOf(-4.7));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-4.7));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -161,7 +161,7 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 		isStatic(formula, node, false);
 		hasABCVars(formula, node);
 		//Note integer math
-		evaluatesTo(formula, node, Double.valueOf(-2.5));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(-2.5));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -181,7 +181,7 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 		assertEquals("a", var0.getName());
 		assertEquals(getGlobalScopeInst(), var0.getScope());
 		//Note integer math
-		evaluatesTo(formula, node, Double.valueOf(0.2));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(0.2));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -198,7 +198,7 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 		isStatic(formula, node, false);
 		hasABVars(formula, node);
 		//Note integer math
-		evaluatesTo(formula, node, Double.valueOf(1.1));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(1.1));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -215,7 +215,7 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 		isStatic(formula, node, false);
 		hasABVars(formula, node);
 		//Note integer math
-		evaluatesTo(formula, node, Boolean.FALSE);
+		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -243,7 +243,7 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 		isStatic(formula, node, false);
 		hasABVars(formula, node);
 		//Note integer math
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -260,7 +260,7 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 		isStatic(formula, node, false);
 		hasABVars(formula, node);
 		//Note integer math
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -287,7 +287,7 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, false);
 		hasABCVars(formula, node);
-		evaluatesTo(formula, node, Double.valueOf(1.8));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(1.8));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -304,7 +304,7 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 		isValid(formula, node, numberManager, null);
 		isStatic(formula, node, false);
 		hasABCVars(formula, node);
-		evaluatesTo(formula, node, Double.valueOf(2));
+		evaluatesTo(numberManager, formula, node, Double.valueOf(2));
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -398,7 +398,7 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 		assertEquals(1, vars.size());
 		VariableID<?> var0 = vars.get(0);
 		assertEquals("a", var0.getName());
-		evaluatesTo(formula, node, Boolean.TRUE);
+		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/AggressiveSolverManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/AggressiveSolverManagerTest.java
@@ -128,7 +128,7 @@ public class AggressiveSolverManagerTest extends AbstractSolverManagerTest
 		manager.addModifier(mod, modifier, strInst);
 		assertEquals(3, store.get(mod));
 
-		ComplexNEPFormula formula = new ComplexNEPFormula("mod");
+		ComplexNEPFormula formula = new ComplexNEPFormula("mod", numberManager);
 		Modifier<Number> modMod = AbstractModifier.add(formula, 100);
 
 		manager.addModifier(str, modMod, strInst);

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/DynamicSolverManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/DynamicSolverManagerTest.java
@@ -169,7 +169,7 @@ public class DynamicSolverManagerTest extends AbstractSolverManagerTest
 		getVarLibrary().assertLegalVariableID("result", globalScope, numberManager);
 
 		ComplexNEPFormula<Number> dynamicformula =
-				new ComplexNEPFormula<Number>("dynamic(active, quantity)");
+				new ComplexNEPFormula<Number>("dynamic(active, quantity)", numberManager);
 		Modifier<Number> dynamicMod = AbstractModifier.add(dynamicformula, 100);
 
 		VariableID<Limb> active = (VariableID<Limb>) getVarLibrary()
@@ -429,7 +429,7 @@ public class DynamicSolverManagerTest extends AbstractSolverManagerTest
 
 		getFunctionLibrary().addFunction(new Dynamic());
 		ComplexNEPFormula<Number> dynamicformula =
-				new ComplexNEPFormula<Number>("dynamic(equipVar, localVar)");
+				new ComplexNEPFormula<Number>("dynamic(equipVar, localVar)", numberManager);
 		Modifier<Number> dynamicMod = AbstractModifier.add(dynamicformula, 100);
 
 		manager.addModifier(resultID, dynamicMod, source);

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/SolverTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/SolverTest.java
@@ -57,8 +57,8 @@ public class SolverTest extends TestCase
 		sfs.getLegalScopeLibrary().registerScope(new SimpleLegalScope(globalScope, "STAT"));
 		str = indSetup.getInstanceFactory().get("STAT", new MockStat("STR"));
 		con = indSetup.getInstanceFactory().get("STAT", new MockStat("CON"));
-		evalManager = managerFactory
-			.generateEvaluationManager(indSetup.getFormulaManager(), numberManager);
+		evalManager =
+				managerFactory.generateEvaluationManager(indSetup.getFormulaManager());
 	}
 
 	@Test

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/testsupport/AbstractSolverManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/testsupport/AbstractSolverManagerTest.java
@@ -193,7 +193,7 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 	public void testComplex()
 	{
 		ScopeInstance source = globalScopeInst;
-		ComplexNEPFormula formula = new ComplexNEPFormula("arms+legs");
+		ComplexNEPFormula formula = new ComplexNEPFormula("arms+legs", numberManager);
 		Modifier<Number> formulaMod = AbstractModifier.add(formula, 100);
 		varLibrary.assertLegalVariableID("Limbs", globalScope, numberManager);
 		varLibrary.assertLegalVariableID("arms", globalScope, numberManager);
@@ -234,10 +234,10 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 	public void testChained()
 	{
 		ScopeInstance source = globalScopeInst;
-		ComplexNEPFormula formula = new ComplexNEPFormula("arms+legs");
+		ComplexNEPFormula formula = new ComplexNEPFormula("arms+legs", numberManager);
 		Modifier<Number> limbsMod = AbstractModifier.add(formula, 100);
 
-		ComplexNEPFormula handsformula = new ComplexNEPFormula("fingers/5");
+		ComplexNEPFormula handsformula = new ComplexNEPFormula("fingers/5", numberManager);
 		Modifier<Number> handsMod = AbstractModifier.add(handsformula, 100);
 
 		varLibrary.assertLegalVariableID("Limbs", globalScope, numberManager);
@@ -344,13 +344,13 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 	public void testCircular()
 	{
 		ScopeInstance source = globalScopeInst;
-		ComplexNEPFormula formula = new ComplexNEPFormula("arms+legs");
+		ComplexNEPFormula formula = new ComplexNEPFormula("arms+legs", numberManager);
 		Modifier<Number> limbsMod = AbstractModifier.add(formula, 100);
 
-		ComplexNEPFormula handsformula = new ComplexNEPFormula("fingers/5");
+		ComplexNEPFormula handsformula = new ComplexNEPFormula("fingers/5", numberManager);
 		Modifier<Number> handsMod = AbstractModifier.add(handsformula, 100);
 
-		ComplexNEPFormula fingersformula = new ComplexNEPFormula("limbs*5");
+		ComplexNEPFormula fingersformula = new ComplexNEPFormula("limbs*5", numberManager);
 		Modifier<Number> fingersMod = AbstractModifier.add(fingersformula, 100);
 
 		varLibrary.assertLegalVariableID("Limbs", globalScope, numberManager);
@@ -414,10 +414,10 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 	public void testIndependence()
 	{
 		ScopeInstance source = globalScopeInst;
-		ComplexNEPFormula formula = new ComplexNEPFormula("arms+legs");
+		ComplexNEPFormula formula = new ComplexNEPFormula("arms+legs", numberManager);
 		Modifier<Number> limbsMod = AbstractModifier.add(formula, 100);
 
-		ComplexNEPFormula handsformula = new ComplexNEPFormula("fingers/5");
+		ComplexNEPFormula handsformula = new ComplexNEPFormula("fingers/5", numberManager);
 		Modifier<Number> handsMod = AbstractModifier.add(handsformula, 100);
 
 		varLibrary.assertLegalVariableID("Limbs", globalScope, numberManager);
@@ -477,10 +477,10 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 	public void testAssertion()
 	{
 		ScopeInstance source = globalScopeInst;
-		ComplexNEPFormula five = new ComplexNEPFormula("5");
+		ComplexNEPFormula five = new ComplexNEPFormula("5", numberManager);
 		Modifier<Number> numMod = AbstractModifier.add(five, 100);
 
-		ComplexNEPFormula fiveString = new ComplexNEPFormula("\"4\"");
+		ComplexNEPFormula fiveString = new ComplexNEPFormula("\"4\"", numberManager);
 		Modifier<Number> strMod = AbstractModifier.add(fiveString, 200);
 
 		varLibrary.assertLegalVariableID("Limbs", globalScope, numberManager);

--- a/PCGen-Formula/code/src/test/pcgen/base/testsupport/AbstractFormulaTestCase.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/testsupport/AbstractFormulaTestCase.java
@@ -146,7 +146,8 @@ public abstract class AbstractFormulaTestCase extends TestCase
 	{
 		SemanticsVisitor semanticsVisitor = new SemanticsVisitor();
 		FormulaSemantics semantics = managerFactory.generateFormulaSemantics(
-			localSetup.getFormulaManager(), getGlobalScope(), assertedFormat);
+			localSetup.getFormulaManager(), getGlobalScope());
+		semantics = semantics.getWith(FormulaSemantics.ASSERTED, assertedFormat);
 		semanticsVisitor.visit(node, semantics);
 		if (!semantics.isValid())
 		{
@@ -167,16 +168,19 @@ public abstract class AbstractFormulaTestCase extends TestCase
 		}
 	}
 
-	public void evaluatesTo(String formula, SimpleNode node, Object valueOf)
+	public void evaluatesTo(FormatManager<?> formatManager, String formula,
+		SimpleNode node, Object valueOf)
 	{
 		EvaluationManager manager = generateManager();
-		performEvaluation(formula, node, valueOf, manager);
+		performEvaluation(formatManager, formula, node, valueOf, manager);
 	}
 
-	public void performEvaluation(String formula, SimpleNode node,
-		Object valueOf, EvaluationManager manager)
+	public void performEvaluation(FormatManager<?> formatManager, String formula,
+		SimpleNode node, Object valueOf, EvaluationManager manager)
 	{
-		Object result = new EvaluateVisitor().visit(node, manager);
+		EvaluationManager evalManager =
+				manager.getWith(EvaluationManager.ASSERTED, formatManager);
+		Object result = new EvaluateVisitor().visit(node, evalManager);
 		if (result.equals(valueOf))
 		{
 			return;
@@ -205,8 +209,8 @@ public abstract class AbstractFormulaTestCase extends TestCase
 
 	public EvaluationManager generateManager()
 	{
-		EvaluationManager em = managerFactory
-			.generateEvaluationManager(localSetup.getFormulaManager(), numberManager);
+		EvaluationManager em =
+				managerFactory.generateEvaluationManager(localSetup.getFormulaManager());
 		return em.getWith(EvaluationManager.INSTANCE, getGlobalScopeInst());
 	}
 
@@ -220,7 +224,8 @@ public abstract class AbstractFormulaTestCase extends TestCase
 	{
 		SemanticsVisitor semanticsVisitor = new SemanticsVisitor();
 		FormulaSemantics semantics = managerFactory.generateFormulaSemantics(
-			localSetup.getFormulaManager(), getGlobalScope(), assertedFormat);
+			localSetup.getFormulaManager(), getGlobalScope());
+		semantics = semantics.getWith(FormulaSemantics.ASSERTED, assertedFormat);
 		semanticsVisitor.visit(node, semantics);
 		if (semantics.isValid())
 		{
@@ -232,7 +237,7 @@ public abstract class AbstractFormulaTestCase extends TestCase
 	protected List<VariableID<?>> getVariables(SimpleNode node)
 	{
 		DependencyManager fdm = managerFactory
-			.generateDependencyManager(getFormulaManager(), getGlobalScopeInst(), null);
+			.generateDependencyManager(getFormulaManager(), getGlobalScopeInst());
 		fdm = managerFactory.withVariables(fdm);
 		new DependencyVisitor().visit(node, fdm);
 		return fdm.get(DependencyManager.VARIABLES).getVariables();


### PR DESCRIPTION

With this change, a NEPFormula is provided the FormatManager, which simplifies how an EvaluationManager, DependencyManager or FormulaSemantics is constructed.  Any assertion of the format is not done initially, but is done later on once it is known what the format is that is expected.  This helps reduce the number of calls in the tests that have "null" as an argument, indicating this is potentially a better architecture in that something is optionally added when valuable, vs passing null into a factory.

A side effect it makes it much easier for a NEPFormula to be directly solved by a SolverManager (without being loaded into a Modifier and be part of a variable).  This enables some additional capabilities. In the PCGen sense, this might allow (for example), INFOVARS to actually take in small one-time calculations rather than having to always be passed in a pure variable.  This can greatly simplify what local variables are required, reducing potential variable pollution within the data.
