### PR TITLE
Alter how scopes are stored.

### DIFF
--- a/PCGen-Formula/code/src/java/pcgen/base/formula/base/LegalScopeLibrary.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/base/LegalScopeLibrary.java
@@ -69,14 +69,38 @@ public class LegalScopeLibrary
 		{
 			throw new IllegalArgumentException("LegalScope must have a name");
 		}
-		LegalScope current = scopes.get(name);
+		if (name.indexOf('.') != -1)
+		{
+			throw new IllegalArgumentException("LegalScope name must not contain a period '.'");
+		}
+		String fullName = buildFullName(scope);
+		LegalScope current = scopes.get(fullName);
 		if ((current != null) && !current.equals(scope))
 		{
-			throw new IllegalArgumentException(
-				"A Scope with name " + name + " is already registered");
+			throw new IllegalArgumentException("A Scope with name fully qualified name "
+				+ fullName + " is already registered");
 		}
 		scopeChildren.addToListFor(scope.getParentScope(), scope);
-		scopes.put(name, scope);
+		scopes.put(fullName, scope);
+	}
+
+	private String buildFullName(LegalScope scope)
+	{
+		StringBuilder stringBuilder = new StringBuilder();
+		internalBuildFullName(stringBuilder, scope);
+		return stringBuilder.toString();
+	}
+
+	private void internalBuildFullName(StringBuilder stringBuilder,
+		LegalScope scope)
+	{
+		LegalScope parent = scope.getParentScope();
+		if (parent != null)
+		{
+			internalBuildFullName(stringBuilder, scope.getParentScope());
+			stringBuilder.append('.');
+		}
+		stringBuilder.append(scope.getName());
 	}
 
 	/**

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/base/LegalScopeLibraryTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/base/LegalScopeLibraryTest.java
@@ -52,7 +52,7 @@ public class LegalScopeLibraryTest extends TestCase
 		library.registerScope(subScope);
 		try
 		{
-			library.registerScope(new SimpleLegalScope(null, "SubScope"));
+			library.registerScope(new SimpleLegalScope(globalScope, "SubScope"));
 			fail("dupe name be rejected in registerScope");
 		}
 		catch (IllegalArgumentException e)
@@ -90,7 +90,7 @@ public class LegalScopeLibraryTest extends TestCase
 		library.registerScope(globalScope);
 		//test getScope
 		assertEquals(globalScope, library.getScope("Global"));
-		assertEquals(subScope, library.getScope("SubScope"));
+		assertEquals(subScope, library.getScope("Global.SubScope"));
 		assert(library.getScope("OtherScope") == null);
 		assert(library.getScope(null) == null);
 	}

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/base/VariableLibraryTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/base/VariableLibraryTest.java
@@ -355,9 +355,9 @@ public class VariableLibraryTest extends TestCase
 		LegalScope spScope = new SimpleLegalScope(globalScope, "Spell");
 		varScopeLib.registerScope(spScope);
 		SimpleVarScoped eq = new SimpleVarScoped();
-		eq.scopeName = "Equipment";
+		eq.scopeName = "Global.Equipment";
 		eq.name = "Sword";
-		ScopeInstance eqInst = instanceFactory.get("Equipment", eq);
+		ScopeInstance eqInst = instanceFactory.get("Global.Equipment", eq);
 		try
 		{
 			varLib.getVariableID(null, "Walk");
@@ -444,16 +444,16 @@ public class VariableLibraryTest extends TestCase
 		LegalScope eqScope = new SimpleLegalScope(globalScope, "Equipment");
 		varScopeLib.registerScope(eqScope);
 		SimpleVarScoped eq = new SimpleVarScoped();
-		eq.scopeName = "Equipment";
+		eq.scopeName = "Global.Equipment";
 		eq.name = "Sword";
-		ScopeInstance eqInst = instanceFactory.get("Equipment", eq);
+		ScopeInstance eqInst = instanceFactory.get("Global.Equipment", eq);
 		LegalScope eqPartScope = new SimpleLegalScope(eqScope, "Part");
 		varScopeLib.registerScope(eqPartScope);
 		SimpleVarScoped eqpart = new SimpleVarScoped();
-		eqpart.scopeName = "Part";
+		eqpart.scopeName = "Global.Equipment.Part";
 		eqpart.name = "Mod";
 		eqpart.parent = eq;
-		ScopeInstance eqPartInst = instanceFactory.get("Part", eqpart);
+		ScopeInstance eqPartInst = instanceFactory.get("Global.Equipment.Part", eqpart);
 		assertTrue(
 			varLib.assertLegalVariableID("Walk", globalScope, numberManager));
 		assertTrue(
@@ -541,15 +541,15 @@ public class VariableLibraryTest extends TestCase
 				new SimpleLegalScope(globalScope, "Equipment");
 		varScopeLib.registerScope(eqScope);
 		SimpleVarScoped eq = new SimpleVarScoped();
-		eq.scopeName = "Equipment";
+		eq.scopeName = "Global.Equipment";
 		eq.name = "Sword";
-		ScopeInstance eqInst = instanceFactory.get("Equipment", eq);
+		ScopeInstance eqInst = instanceFactory.get("Global.Equipment", eq);
 		LegalScope abScope = new SimpleLegalScope(globalScope, "Ability");
 		varScopeLib.registerScope(abScope);
 		SimpleVarScoped ab = new SimpleVarScoped();
-		ab.scopeName = "Ability";
+		ab.scopeName = "Global.Ability";
 		ab.name = "Dodge";
-		ScopeInstance abInst = instanceFactory.get("Ability", ab);
+		ScopeInstance abInst = instanceFactory.get("Global.Ability", ab);
 
 		assertTrue(
 			varLib.assertLegalVariableID("Walk", eqScope, numberManager));

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/ScopeInstanceFactoryTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/ScopeInstanceFactoryTest.java
@@ -119,16 +119,16 @@ public class ScopeInstanceFactoryTest extends TestCase
 		{
 			//ok
 		}
-		Scoped lvs = new Scoped("LVar", "Local", gvs);
-		ScopeInstance lsi = factory.get("Local", lvs);
+		Scoped lvs = new Scoped("LVar", "Global.Local", gvs);
+		ScopeInstance lsi = factory.get("Global.Local", lvs);
 		assertTrue(local.equals(lsi.getLegalScope()));
 		assertTrue(scopeInst.equals(lsi.getParentScope()));
 		assertEquals("Local", lsi.getLegalScope().getName());
 
 		SimpleLegalScope sublocal = new SimpleLegalScope(local, "SubLocal");
 		library.registerScope(sublocal);
-		Scoped slvs = new Scoped("SVar", "SubLocal", lvs);
-		ScopeInstance slsi = factory.get("Local", slvs);
+		Scoped slvs = new Scoped("SVar", "Global.Local.SubLocal", lvs);
+		ScopeInstance slsi = factory.get("Global.Local", slvs);
 		assertTrue(local.equals(slsi.getLegalScope()));
 		assertTrue(scopeInst.equals(slsi.getParentScope()));
 		assertEquals("Local", slsi.getLegalScope().getName());

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/AggressiveSolverManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/AggressiveSolverManagerTest.java
@@ -118,7 +118,7 @@ public class AggressiveSolverManagerTest extends AbstractSolverManagerTest
 		SimpleLegalScope localScope = new SimpleLegalScope(globalScope, "STAT");
 		getScopeLibrary().registerScope(localScope);
 
-		ScopeInstance strInst = getInstanceFactory().get("STAT", new MockStat("Strength"));
+		ScopeInstance strInst = getInstanceFactory().get("Global.STAT", new MockStat("Strength"));
 
 		getVariableLibrary().assertLegalVariableID("Mod", localScope, numberManager);
 		VariableID<Number> mod =

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/DynamicSolverManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/DynamicSolverManagerTest.java
@@ -178,9 +178,9 @@ public class DynamicSolverManagerTest extends AbstractSolverManagerTest
 			.getVariableID(getGlobalScopeInst(), "Result");
 
 		Limb hands = limbManager.convert("Hands");
-		ScopeInstance handsInst = getScopeInstance("LIMB", hands);
+		ScopeInstance handsInst = getScopeInstance("Global.LIMB", hands);
 		Limb fingers = limbManager.convert("Fingers");
-		ScopeInstance fingersInst = getScopeInstance("LIMB", fingers);
+		ScopeInstance fingersInst = getScopeInstance("Global.LIMB", fingers);
 
 		VariableID<Number> handsID =
 				(VariableID<Number>) getVarLibrary().getVariableID(handsInst, "Quantity");
@@ -297,7 +297,7 @@ public class DynamicSolverManagerTest extends AbstractSolverManagerTest
 		@Override
 		public String getLocalScopeName()
 		{
-			return "LIMB";
+			return "Global.LIMB";
 		}
 
 		@Override
@@ -361,7 +361,7 @@ public class DynamicSolverManagerTest extends AbstractSolverManagerTest
 			VarScoped vs = (VarScoped) args[0].jjtAccept(visitor, em);
 			FormulaManager fManager = em.get(EvaluationManager.FMANAGER);
 			ScopeInstanceFactory siFactory = fManager.getScopeInstanceFactory();
-			ScopeInstance scopeInst = siFactory.get("LIMB", vs);
+			ScopeInstance scopeInst = siFactory.get("Global.LIMB", vs);
 			//Rest of Equation
 			return args[1].jjtAccept(visitor,
 				em.getWith(EvaluationManager.INSTANCE, scopeInst));
@@ -376,7 +376,7 @@ public class DynamicSolverManagerTest extends AbstractSolverManagerTest
 			TrainingStrategy ts = new TrainingStrategy();
 			DependencyManager trainer = dm.getWith(DependencyManager.VARSTRATEGY, ts);
 			visitor.visitVariable(varName, trainer);
-			DynamicDependency dd = new DynamicDependency(ts.getControlVar(), "LIMB");
+			DynamicDependency dd = new DynamicDependency(ts.getControlVar(), "Global.LIMB");
 			DependencyManager dynamic = dm.getWith(DependencyManager.VARSTRATEGY, dd);
 			FormatManager<?> returnFormat = visitor.visitVariable(name, dynamic);
 			dm.get(DependencyManager.DYNAMIC).addDependency(dd);
@@ -404,9 +404,9 @@ public class DynamicSolverManagerTest extends AbstractSolverManagerTest
 			.getVariableID(getGlobalScopeInst(), "ResultVar");
 
 		Limb equip = limbManager.convert("EquipKey");
-		ScopeInstance equipInst = getScopeInstance("LIMB", equip);
+		ScopeInstance equipInst = getScopeInstance("Global.LIMB", equip);
 		Limb equipalt  = limbManager.convert("EquipAlt");
-		ScopeInstance altInst = getScopeInstance("LIMB", equipalt);
+		ScopeInstance altInst = getScopeInstance("Global.LIMB", equipalt);
 
 		VariableID<Number> equipID =
 				(VariableID<Number>) getVarLibrary().getVariableID(equipInst, "LocalVar");

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/SolverTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/SolverTest.java
@@ -55,8 +55,8 @@ public class SolverTest extends TestCase
 		IndividualSetup indSetup = new IndividualSetup(sfs, "Global", new SimpleVariableStore());
 		inst = indSetup.getGlobalScopeInst();
 		sfs.getLegalScopeLibrary().registerScope(new SimpleLegalScope(globalScope, "STAT"));
-		str = indSetup.getInstanceFactory().get("STAT", new MockStat("STR"));
-		con = indSetup.getInstanceFactory().get("STAT", new MockStat("CON"));
+		str = indSetup.getInstanceFactory().get("Global.STAT", new MockStat("STR"));
+		con = indSetup.getInstanceFactory().get("Global.STAT", new MockStat("CON"));
 		evalManager =
 				managerFactory.generateEvaluationManager(indSetup.getFormulaManager());
 	}

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/testsupport/AbstractSolverManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/testsupport/AbstractSolverManagerTest.java
@@ -181,7 +181,7 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 
 		SimpleLegalScope localScope = new SimpleLegalScope(globalScope, "STAT");
 		getScopeLibrary().registerScope(localScope);
-		ScopeInstance strInst = getInstanceFactory().get("STAT", new MockStat("Strength"));
+		ScopeInstance strInst = getInstanceFactory().get("Global.STAT", new MockStat("Strength"));
 
 		getManager().addModifier(hitpoints, AbstractModifier.setNumber(12, 3), strInst);
 		assertEquals(6, store.get(hitpoints));

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/testsupport/MockStat.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/testsupport/MockStat.java
@@ -38,7 +38,7 @@ public class MockStat implements VarScoped
 	@Override
 	public String getLocalScopeName()
 	{
-		return "STAT";
+		return "Global.STAT";
 	}
 
 	@Override


### PR DESCRIPTION
"Local" is now stored as "Global.Local" forcing the period as a
separator.  This has a few side effects:
(1) reuse of a local is possible since scopes are not absolutely unique
anymore, they are unique as far as their absolute address.
(2) A local scope should only define its local name.  Previously some
uses of this library were using A.B as the local name, now it should
provide B and this class will derive the "A." portion