### PR TITLE
LegalScope Parent is Optional

### DIFF
--- a/PCGen-Formula/code/src/java/pcgen/base/formula/base/LegalScope.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/base/LegalScope.java
@@ -17,6 +17,8 @@
  */
 package pcgen.base.formula.base;
 
+import java.util.Optional;
+
 /**
  * LegalScope identifies a scope in which a particular part of a formula
  * (usually a variable) is valid.
@@ -58,7 +60,7 @@ public interface LegalScope
 	 * 
 	 * @return The LegalScope that serves as a "parent" for this LegalScope
 	 */
-	public LegalScope getParentScope();
+	public Optional<LegalScope> getParentScope();
 
 	/**
 	 * Returns the name of this LegalScope.
@@ -78,11 +80,12 @@ public interface LegalScope
 	{
 		StringBuilder sb = new StringBuilder();
 		sb.append(legalScope.getName());
-		LegalScope current = legalScope;
-		while ((current = current.getParentScope()) != null)
+		Optional<LegalScope> current = legalScope.getParentScope();
+		while (current.isPresent())
 		{
 			sb.insert(0, '.');
-			sb.insert(0, current.getName());
+			sb.insert(0, current.get().getName());
+			current = current.get().getParentScope();
 		}
 		return sb.toString();
 	}

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/inst/ScopeManagerInst.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/inst/ScopeManagerInst.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.util.CaseInsensitiveMap;
@@ -69,12 +70,12 @@ public class ScopeManagerInst implements LegalScopeManager
 			throw new IllegalArgumentException(
 				"LegalScope name must not contain a period '.'");
 		}
-		LegalScope parent = scope.getParentScope();
-		if ((parent != null) && !recognizesScope(parent))
+		Optional<LegalScope> parent = scope.getParentScope();
+		if (parent.isPresent() && !recognizesScope(parent.get()))
 		{
 			throw new IllegalArgumentException(
 				"Attempted to register Scope " + scope.getName() + " before parent scope "
-					+ parent.getName() + " was registered");
+					+ parent.get().getName() + " was registered");
 		}
 		String fullName = LegalScope.getFullName(scope);
 		LegalScope current = scopes.get(fullName);
@@ -83,7 +84,10 @@ public class ScopeManagerInst implements LegalScopeManager
 			throw new IllegalArgumentException("A Scope with name fully qualified name "
 				+ fullName + " is already registered");
 		}
-		scopeChildren.addToListFor(parent, scope);
+		if (parent.isPresent())
+		{
+			scopeChildren.addToListFor(parent.get(), scope);
+		}
 		scopes.put(fullName, scope);
 	}
 

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/inst/SimpleLegalScope.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/inst/SimpleLegalScope.java
@@ -18,6 +18,7 @@
 package pcgen.base.formula.inst;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import pcgen.base.formula.base.LegalScope;
 
@@ -30,7 +31,7 @@ public class SimpleLegalScope implements LegalScope
 	/**
 	 * The LegalScope that is a parent of this LegalScope.
 	 */
-	private final LegalScope parent;
+	private final Optional<LegalScope> parent;
 
 	/**
 	 * The name of this LegalScope.
@@ -46,9 +47,28 @@ public class SimpleLegalScope implements LegalScope
 	 * @param name
 	 *            The name of this SimpleLegalScope
 	 */
+	public SimpleLegalScope(String name)
+	{
+		this(Optional.empty(), name);
+	}
+
+	/**
+	 * Constructs a new LegalScope with the given parent LegalScope and name.
+	 * 
+	 * @param parentScope
+	 *            The LegalScope that is a parent of this LegalScope. May be
+	 *            null to represent global
+	 * @param name
+	 *            The name of this SimpleLegalScope
+	 */
 	public SimpleLegalScope(LegalScope parentScope, String name)
 	{
-		this.parent = parentScope;
+		this(Optional.of(parentScope), name);
+	}
+
+	private SimpleLegalScope(Optional<LegalScope> parentScope, String name)
+	{
+		this.parent = Objects.requireNonNull(parentScope);
 		this.name = Objects.requireNonNull(name);
 	}
 
@@ -60,7 +80,7 @@ public class SimpleLegalScope implements LegalScope
 	 * @return The LegalScope that serves as a "parent" for this LegalScope
 	 */
 	@Override
-	public LegalScope getParentScope()
+	public Optional<LegalScope> getParentScope()
 	{
 		return parent;
 	}

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/inst/SimpleScopeInstance.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/inst/SimpleScopeInstance.java
@@ -63,14 +63,14 @@ public class SimpleScopeInstance implements ScopeInstance
 		}
 		if (parent == null)
 		{
-			if (scope.getParentScope() != null)
+			if (scope.getParentScope().isPresent())
 			{
 				throw new IllegalArgumentException(
 					"Incompatible ScopeInstance and LegalScope: "
 						+ "Parent may only be null " + "when LegalScope has no parent");
 			}
 		}
-		else if (scope.getParentScope() == null)
+		else if (!scope.getParentScope().isPresent())
 		{
 			throw new IllegalArgumentException(
 				"Incompatible ScopeInstance and LegalScope: "
@@ -79,11 +79,12 @@ public class SimpleScopeInstance implements ScopeInstance
 		}
 		else
 		{
-			if (!scope.getParentScope().equals(parent.getLegalScope()))
+			LegalScope parentScope = scope.getParentScope().get();
+			if (!parentScope.equals(parent.getLegalScope()))
 			{
-				throw new IllegalArgumentException("Incompatible ScopeInstance ("
-					+ parent.getLegalScope().getName() + ") and LegalScope parent ("
-					+ scope.getParentScope().getName() + ")");
+				throw new IllegalArgumentException(
+					"Incompatible ScopeInstance (" + parent.getLegalScope().getName()
+						+ ") and LegalScope parent (" + parentScope.getName() + ")");
 			}
 		}
 		this.parent = parent;

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/base/ScopeManagerInstTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/base/ScopeManagerInstTest.java
@@ -2,6 +2,7 @@ package pcgen.base.formula.base;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.Test;
 
@@ -13,7 +14,7 @@ public class ScopeManagerInstTest extends TestCase
 {
 
 	private ScopeManagerInst legalScopeManager;
-	SimpleLegalScope globalScope = new SimpleLegalScope(null, "Global");
+	SimpleLegalScope globalScope = new SimpleLegalScope("Global");
 	SimpleLegalScope subScope = new SimpleLegalScope(globalScope, "SubScope");
 	SimpleLegalScope otherScope = new SimpleLegalScope(globalScope, "OtherScope");
 
@@ -189,9 +190,9 @@ public class ScopeManagerInstTest extends TestCase
 	{
 
 		@Override
-		public LegalScope getParentScope()
+		public Optional<LegalScope> getParentScope()
 		{
-			return null;
+			return Optional.empty();
 		}
 
 		@Override

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/base/VariableIDTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/base/VariableIDTest.java
@@ -38,7 +38,7 @@ public class VariableIDTest extends TestCase
 	{
 		super.setUp();
 		legalScopeManager = new ScopeManagerInst();
-		legalScopeManager.registerScope(new SimpleLegalScope(null, "Global"));
+		legalScopeManager.registerScope(new SimpleLegalScope("Global"));
 		instanceFactory = new SimpleScopeInstanceFactory(legalScopeManager);
 	}
 
@@ -114,7 +114,7 @@ public class VariableIDTest extends TestCase
 	public void testEquals()
 	{
 		ScopeInstance globalInst = instanceFactory.getGlobalInstance("Global");
-		legalScopeManager.registerScope(new SimpleLegalScope(null, "Global2"));
+		legalScopeManager.registerScope(new SimpleLegalScope("Global2"));
 		ScopeInstance globalInst2 = instanceFactory.getGlobalInstance("Global2");
 		VariableID vid1 = new VariableID(globalInst, numberManager, "test");
 		VariableID vid2 = new VariableID(globalInst, numberManager, "test");
@@ -132,7 +132,7 @@ public class VariableIDTest extends TestCase
 	public void testHashCode()
 	{
 		ScopeInstance globalInst = instanceFactory.getGlobalInstance("Global");
-		legalScopeManager.registerScope(new SimpleLegalScope(null, "Global2"));
+		legalScopeManager.registerScope(new SimpleLegalScope("Global2"));
 		ScopeInstance globalInst2 = instanceFactory.getGlobalInstance("Global2");
 		VariableID vid1 = new VariableID(globalInst, numberManager, "test");
 		VariableID vid2 = new VariableID(globalInst, numberManager, "test");

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/base/VariableLibraryTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/base/VariableLibraryTest.java
@@ -64,7 +64,7 @@ public class VariableLibraryTest extends TestCase
 	@Test
 	public void testAssertVariableFail()
 	{
-		LegalScope globalScope = new SimpleLegalScope(null, "Global");
+		LegalScope globalScope = new SimpleLegalScope("Global");
 		try
 		{
 			variableLibrary.assertLegalVariableID(null, globalScope, numberManager);
@@ -136,7 +136,7 @@ public class VariableLibraryTest extends TestCase
 	@Test
 	public void testAssertVariable()
 	{
-		SimpleLegalScope globalScope = new SimpleLegalScope(null, "Global");
+		SimpleLegalScope globalScope = new SimpleLegalScope("Global");
 		LegalScope spScope = new SimpleLegalScope(globalScope, "Spell");
 		SimpleLegalScope eqScope = new SimpleLegalScope(globalScope, "Equipment");
 		LegalScope eqPartScope = new SimpleLegalScope(eqScope, "Part");
@@ -217,7 +217,7 @@ public class VariableLibraryTest extends TestCase
 	@Test
 	public void testIsLegalVIDFail()
 	{
-		LegalScope globalScope = new SimpleLegalScope(null, "Global");
+		LegalScope globalScope = new SimpleLegalScope("Global");
 		legalScopeManager.registerScope(globalScope);
 		variableLibrary.assertLegalVariableID("Walk", globalScope, numberManager);
 		try
@@ -242,7 +242,7 @@ public class VariableLibraryTest extends TestCase
 	@Test
 	public void testIsLegalVID()
 	{
-		SimpleLegalScope globalScope = new SimpleLegalScope(null, "Global");
+		SimpleLegalScope globalScope = new SimpleLegalScope("Global");
 		LegalScope spScope = new SimpleLegalScope(globalScope, "Spell");
 		SimpleLegalScope eqScope = new SimpleLegalScope(globalScope, "Equipment");
 		LegalScope eqPartScope = new SimpleLegalScope(eqScope, "Part");
@@ -280,7 +280,7 @@ public class VariableLibraryTest extends TestCase
 	@Test
 	public void testGetVIDFail()
 	{
-		LegalScope globalScope = new SimpleLegalScope(null, "Global");
+		LegalScope globalScope = new SimpleLegalScope("Global");
 		legalScopeManager.registerScope(globalScope);
 		ScopeInstance globalInst = instanceFactory.getGlobalInstance("Global");
 		LegalScope eqScope = new SimpleLegalScope(globalScope, "Equipment");
@@ -370,7 +370,7 @@ public class VariableLibraryTest extends TestCase
 	@Test
 	public void testGetVID()
 	{
-		LegalScope globalScope = new SimpleLegalScope(null, "Global");
+		LegalScope globalScope = new SimpleLegalScope("Global");
 		legalScopeManager.registerScope(globalScope);
 		ScopeInstance globalInst = instanceFactory.getGlobalInstance("Global");
 		LegalScope eqScope = new SimpleLegalScope(globalScope, "Equipment");
@@ -425,7 +425,7 @@ public class VariableLibraryTest extends TestCase
 	@Test
 	public void testGetVariableFormat()
 	{
-		LegalScope globalScope = new SimpleLegalScope(null, "Global");
+		LegalScope globalScope = new SimpleLegalScope("Global");
 		LegalScope eqScope = new SimpleLegalScope(globalScope, "Equipment");
 		legalScopeManager.registerScope(globalScope);
 		legalScopeManager.registerScope(eqScope);
@@ -464,7 +464,7 @@ public class VariableLibraryTest extends TestCase
 	public void testProveReuse()
 	{
 		BooleanManager booleanManager = FormatUtilities.BOOLEAN_MANAGER;
-		SimpleLegalScope globalScope = new SimpleLegalScope(null, "Global");
+		SimpleLegalScope globalScope = new SimpleLegalScope("Global");
 		legalScopeManager.registerScope(globalScope);
 		LegalScope eqScope =
 				new SimpleLegalScope(globalScope, "Equipment");

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleLegalScopeTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleLegalScopeTest.java
@@ -30,7 +30,7 @@ public class SimpleLegalScopeTest extends TestCase
 	protected void setUp() throws Exception
 	{
 		super.setUp();
-		scope = new SimpleLegalScope(null, "Global");
+		scope = new SimpleLegalScope("Global");
 	}
 
 	@Test
@@ -51,7 +51,8 @@ public class SimpleLegalScopeTest extends TestCase
 	public void testIsValid()
 	{
 		SimpleLegalScope local = new SimpleLegalScope(scope, "Local");
-		assertEquals(scope, local.getParentScope());
+		assertTrue(local.getParentScope().isPresent());
+		assertEquals(scope, local.getParentScope().get());
 		assertEquals("Local", local.getName());
 		assertEquals("Local", local.toString());
 	}

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleScopeInstanceFactoryTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleScopeInstanceFactoryTest.java
@@ -38,7 +38,7 @@ public class SimpleScopeInstanceFactoryTest extends TestCase
 		super.setUp();
 		legalScopeManager = new ScopeManagerInst();
 		factory = new SimpleScopeInstanceFactory(legalScopeManager);
-		SimpleLegalScope scope = new SimpleLegalScope(null, "Global");
+		SimpleLegalScope scope = new SimpleLegalScope("Global");
 		legalScopeManager.registerScope(scope);
 		scopeInst = factory.getGlobalInstance("Global");
 		local = new SimpleLegalScope(scope, "Local");

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleScopeInstanceTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleScopeInstanceTest.java
@@ -36,7 +36,7 @@ public class SimpleScopeInstanceTest extends TestCase
 	protected void setUp() throws Exception
 	{
 		super.setUp();
-		scope = new SimpleLegalScope(null, "Global");
+		scope = new SimpleLegalScope("Global");
 		scopeInst = new SimpleScopeInstance(null, scope, GLOBAL_VS);
 		local = new SimpleLegalScope(scope, "Local");
 		localInst = new SimpleScopeInstance(scopeInst, local, LOCAL_VS);

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleVariableStoreTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleVariableStoreTest.java
@@ -35,7 +35,7 @@ public class SimpleVariableStoreTest extends TestCase
 	{
 		super.setUp();
 		legalScopeManager = new ScopeManagerInst();
-		legalScopeManager.registerScope(new SimpleLegalScope(null, "Global"));
+		legalScopeManager.registerScope(new SimpleLegalScope("Global"));
 		instanceFactory = new SimpleScopeInstanceFactory(legalScopeManager);
 	}
 
@@ -97,7 +97,7 @@ public class SimpleVariableStoreTest extends TestCase
 		VariableID vid1 = new VariableID(globalInst, numberManager, "test");
 		VariableID vid2 = new VariableID(globalInst, numberManager, "test");
 		VariableID vid3 = new VariableID(globalInst, numberManager, "test2");
-		legalScopeManager.registerScope(new SimpleLegalScope(null, "Global2"));
+		legalScopeManager.registerScope(new SimpleLegalScope("Global2"));
 		ScopeInstance globalInst2 = instanceFactory.getGlobalInstance("Global2");
 		VariableID vid4 = new VariableID(globalInst2, numberManager, "test");
 		assertNull(varStore.put(vid1, Integer.valueOf(9)));

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/SolverTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/SolverTest.java
@@ -50,7 +50,7 @@ public class SolverTest extends TestCase
 	{
 		super.setUp();
 		SplitFormulaSetup sfs = new SplitFormulaSetup();
-		SimpleLegalScope globalScope = new SimpleLegalScope(null, "Global");
+		SimpleLegalScope globalScope = new SimpleLegalScope("Global");
 		sfs.getLegalScopeManager().registerScope(globalScope);
 		IndividualSetup indSetup = new IndividualSetup(sfs, new SimpleVariableStore());
 		inst = indSetup.getInstanceFactory().getGlobalInstance("Global");

--- a/PCGen-Formula/code/src/test/pcgen/base/testsupport/AbstractFormulaTestCase.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/testsupport/AbstractFormulaTestCase.java
@@ -65,7 +65,7 @@ public abstract class AbstractFormulaTestCase extends TestCase
 		setup = new SplitFormulaSetup();
 		setup.loadBuiltIns();
 		setup.getLegalScopeManager()
-			.registerScope(new SimpleLegalScope(null, "Global"));
+			.registerScope(new SimpleLegalScope("Global"));
 		localSetup = new IndividualSetup(setup, new SimpleVariableStore());
 		setup.getSolverFactory().addSolverFormat(Number.class, new Modifier(){
 


### PR DESCRIPTION
In the world of further null reduction, this makes the Parent of a LegalScope into an Optional<LegalScope> to avoid null references.