### PR TITLE
Semantics By Exception

### DIFF
--- a/PCGen-Formula/code/src/java/pcgen/base/formula/base/FormulaSemantics.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/base/FormulaSemantics.java
@@ -52,7 +52,6 @@ public class FormulaSemantics
 	 */
 	public FormulaSemantics()
 	{
-		map.put(REPORT, new SemanticsReport());
 	}
 
 	/**
@@ -122,93 +121,6 @@ public class FormulaSemantics
 	 * A TypedKey used for storing the Format of the input object for the formula served
 	 * by this FormulaSemantics.
 	 */
-	public static final TypedKey<FormatManager<?>> INPUT_FORMAT = new TypedKey<>();
-
-	/**
-	 * A TypedKey used for storing a message indicating why the formula served by this
-	 * FormulaSemantics is not valid.
-	 */
-	private static final TypedKey<SemanticsReport> REPORT = new TypedKey<>();
-
-	/**
-	 * Sets the FormulaSemantics to indicate a Formula is not valid, and provides the
-	 * given String as the report indicating why it is invalid.
-	 * 
-	 * @param text
-	 *            The report text, indicating why the Formula is invalid
-	 */
-	public void setInvalid(String text)
-	{
-		SemanticsReport report = get(REPORT);
-		report.setValid(false);
-		report.setReport(text);
-	}
-
-	/**
-	 * Returns the report indicating why the Formula is invalid.
-	 * 
-	 * Is guaranteed to return content only if isValid() returns false.
-	 * 
-	 * @return The report text, indicating why the Formula is invalid
-	 */
-	public String getReport()
-	{
-		return get(REPORT).getReport();
-	}
-
-	/**
-	 * Returns true if the recently processed Formula is valid; false otherwise.
-	 * 
-	 * @return true if the recently processed Formula is valid; false otherwise.
-	 */
-	public boolean isValid()
-	{
-		return get(REPORT).isValid();
-	}
-
-	/**
-	 * Resets this FormulaSemantics to have a clean report.
-	 */
-	public void resetReport()
-	{
-		SemanticsReport report = get(REPORT);
-		report.setValid(true);
-		report.setReport("");
-	}
-
-	/**
-	 * A Class to hold the Report & Validity of the FormulaSemantics.
-	 * 
-	 * Note that this exists because you can't put new items into FormulaSemantics - some
-	 * functions, et al may call getWith and produce a "sub semantics" that is valid
-	 * beyond that point... this needs to be shared among all of those children, so it has
-	 * to be a separate item and internal to the first FormulaSemantics (pre-made)
-	 */
-	private class SemanticsReport
-	{
-		private boolean isValid = true;
-		private String report = "";
-
-		public boolean isValid()
-		{
-			return isValid;
-		}
-
-		public void setValid(boolean isValid)
-		{
-			this.isValid = isValid;
-		}
-
-		public String getReport()
-		{
-			return report;
-		}
-
-		public void setReport(String report)
-		{
-			this.report = report;
-		}
-
-	}
-
+	public static final TypedKey<Optional<FormatManager<?>>> INPUT_FORMAT =
+			new TypedKey<>(Optional.empty());
 }

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/exception/SemanticsException.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/exception/SemanticsException.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.formula.exception;
+
+/**
+ * A SemanticsException is an Exception thrown while a Formula is being built. This
+ * indicates a failure in the semantics rules of a formula.
+ * 
+ * This could mean an assertion of a Number was made, but no variable with an appropriate
+ * name of format Number existed.
+ */
+public class SemanticsException extends Exception
+{
+	/**
+	 * Constructs a new SemanticsException with the given message.
+	 * 
+	 * @param message
+	 *            The message indicating the semantics failure
+	 */
+	public SemanticsException(String message)
+	{
+		super(message);
+	}
+
+	/**
+	 * Constructs a new SemanticsException with the given underlying exception causing the
+	 * failure.
+	 * 
+	 * @param cause
+	 *            The underlying SemanticsFailureException causing a semantics failure
+	 */
+	public SemanticsException(SemanticsFailureException cause)
+	{
+		super(cause);
+	}
+}

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/exception/SemanticsFailureException.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/exception/SemanticsFailureException.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.formula.exception;
+
+/**
+ * A SemanticsException is an Exception thrown while a FormulaSemantics is processing to
+ * indicate a failure in the semantics rules of a formula.
+ * 
+ * This could mean an assertion of a Number was made, but no variable with an appropriate
+ * name of format Number existed.
+ */
+public class SemanticsFailureException extends RuntimeException
+{
+
+	/**
+	 * Constructs a new SemanticsFailureException with the given message and underlying
+	 * cause.
+	 * 
+	 * @param message
+	 *            The message indicating the semantics failure
+	 * @param cause
+	 *            The underlying Throwable causing a semantics failure
+	 */
+	public SemanticsFailureException(String message, Throwable cause)
+	{
+		super(message, cause);
+	}
+
+	/**
+	 * Constructs a new SemanticsFailureException with the given message.
+	 * 
+	 * @param message
+	 *            The message indicating the semantics failure
+	 */
+	public SemanticsFailureException(String message)
+	{
+		super(message);
+	}
+
+}

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/function/AbstractNaryFunction.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/function/AbstractNaryFunction.java
@@ -22,8 +22,9 @@ import java.util.Arrays;
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.DependencyManager;
 import pcgen.base.formula.base.EvaluationManager;
-import pcgen.base.formula.base.FormulaSemantics;
 import pcgen.base.formula.base.FormulaFunction;
+import pcgen.base.formula.base.FormulaSemantics;
+import pcgen.base.formula.exception.SemanticsFailureException;
 import pcgen.base.formula.parse.Node;
 import pcgen.base.formula.visitor.DependencyVisitor;
 import pcgen.base.formula.visitor.EvaluateVisitor;
@@ -54,27 +55,21 @@ public abstract class AbstractNaryFunction implements FormulaFunction
 		int argCount = args.length;
 		if (argCount < 2)
 		{
-			semantics.setInvalid("Function " + getFunctionName()
-				+ " received incorrect # of arguments, expected: 2 got "
-				+ args.length + " " + Arrays.asList(args));
-			return null;
+			throw new SemanticsFailureException("Function " + getFunctionName()
+				+ " received incorrect # of arguments, expected: 2 got " + args.length
+				+ " " + Arrays.asList(args));
 		}
 		for (Node n : args)
 		{
 			@SuppressWarnings("PMD.PrematureDeclaration")
 			FormatManager<?> format =
 					(FormatManager<?>) n.jjtAccept(visitor, semantics);
-			if (!semantics.isValid())
-			{
-				return null;
-			}
 			if (!format.equals(FormatUtilities.NUMBER_MANAGER))
 			{
-				semantics.setInvalid("Parse Error: Invalid Value Format: "
-					+ format + " found in " + n.getClass().getName()
-					+ " found in location requiring a"
-					+ " Number (class cannot be evaluated)");
-				return null;
+				throw new SemanticsFailureException(
+					"Parse Error: Invalid Value Format: " + format + " found in "
+						+ n.getClass().getName() + " found in location requiring a"
+						+ " Number (class cannot be evaluated)");
 			}
 		}
 		return FormatUtilities.NUMBER_MANAGER;

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/function/AbstractUnaryFunction.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/function/AbstractUnaryFunction.java
@@ -22,8 +22,9 @@ import java.util.Arrays;
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.DependencyManager;
 import pcgen.base.formula.base.EvaluationManager;
-import pcgen.base.formula.base.FormulaSemantics;
 import pcgen.base.formula.base.FormulaFunction;
+import pcgen.base.formula.base.FormulaSemantics;
+import pcgen.base.formula.exception.SemanticsFailureException;
 import pcgen.base.formula.parse.Node;
 import pcgen.base.formula.visitor.DependencyVisitor;
 import pcgen.base.formula.visitor.EvaluateVisitor;
@@ -44,27 +45,21 @@ public abstract class AbstractUnaryFunction implements FormulaFunction
 	{
 		if (args.length != 1)
 		{
-			semantics.setInvalid("Function " + getFunctionName()
-				+ " received incorrect # of arguments, expected: 1 got "
-				+ args.length + " " + Arrays.asList(args));
-			return null;
+			throw new SemanticsFailureException("Function " + getFunctionName()
+				+ " received incorrect # of arguments, expected: 1 got " + args.length
+				+ " " + Arrays.asList(args));
 		}
 		@SuppressWarnings("PMD.PrematureDeclaration")
 		FormatManager<?> format =
 				(FormatManager<?>) args[0].jjtAccept(visitor, semantics);
-		if (!semantics.isValid())
-		{
-			return null;
-		}
 		if (!format.equals(FormatUtilities.NUMBER_MANAGER))
 		{
-			semantics.setInvalid("Parse Error: Invalid Value Format: " + format
-				+ " found in " + args[0].getClass().getName()
-				+ " found in location requiring a"
-				+ " Number (class cannot be evaluated)");
-			return null;
+			throw new SemanticsFailureException(
+				"Parse Error: Invalid Value Format: " + format + " found in "
+					+ args[0].getClass().getName() + " found in location requiring a"
+					+ " Number (class cannot be evaluated)");
 		}
-		return format;
+		return FormatUtilities.NUMBER_MANAGER;
 	}
 
 	@Override

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/function/IfFunction.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/function/IfFunction.java
@@ -23,8 +23,9 @@ import java.util.Optional;
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.DependencyManager;
 import pcgen.base.formula.base.EvaluationManager;
-import pcgen.base.formula.base.FormulaSemantics;
 import pcgen.base.formula.base.FormulaFunction;
+import pcgen.base.formula.base.FormulaSemantics;
+import pcgen.base.formula.exception.SemanticsFailureException;
 import pcgen.base.formula.parse.Node;
 import pcgen.base.formula.visitor.DependencyVisitor;
 import pcgen.base.formula.visitor.EvaluateVisitor;
@@ -55,10 +56,9 @@ public class IfFunction implements FormulaFunction
 		int argCount = args.length;
 		if (argCount != 3)
 		{
-			semantics.setInvalid("Function " + getFunctionName()
-				+ " received incorrect # of arguments, expected: 3 got "
-				+ args.length + " " + Arrays.asList(args));
-			return null;
+			throw new SemanticsFailureException("Function " + getFunctionName()
+				+ " received incorrect # of arguments, expected: 3 got " + args.length
+				+ " " + Arrays.asList(args));
 		}
 		//Boolean conditional node
 		Node conditionalNode = args[0];
@@ -66,45 +66,31 @@ public class IfFunction implements FormulaFunction
 		FormatManager<?> format = (FormatManager<?>) conditionalNode.jjtAccept(visitor,
 			semantics.getWith(FormulaSemantics.ASSERTED,
 				Optional.of(FormatUtilities.BOOLEAN_MANAGER)));
-		if (!semantics.isValid())
-		{
-			return null;
-		}
 		if (!FormatUtilities.BOOLEAN_MANAGER.equals(format))
 		{
-			semantics.setInvalid("Parse Error: Invalid Value Format: " + format
-				+ " found in " + conditionalNode.getClass().getName()
+			throw new SemanticsFailureException("Parse Error: Invalid Value Format: "
+				+ format + " found in " + conditionalNode.getClass().getName()
 				+ " found in location requiring a"
 				+ " Boolean (class cannot be evaluated)");
-			return null;
 		}
 
 		//If True node
 		@SuppressWarnings("PMD.PrematureDeclaration")
 		FormatManager<?> tFormat =
 				(FormatManager<?>) args[1].jjtAccept(visitor, semantics);
-		if (!semantics.isValid())
-		{
-			return null;
-		}
 
 		//If False node
 		@SuppressWarnings("PMD.PrematureDeclaration")
 		FormatManager<?> fFormat =
 				(FormatManager<?>) args[2].jjtAccept(visitor, semantics);
-		if (!semantics.isValid())
-		{
-			return null;
-		}
 
 		//Check for Mismatch in formats between True and False results
 		if (!tFormat.equals(fFormat))
 		{
-			semantics.setInvalid("Parse Error: Invalid Value Format: "
+			throw new SemanticsFailureException("Parse Error: Invalid Value Format: "
 				+ fFormat + " found in " + conditionalNode.getClass().getName()
 				+ " found in location requiring a " + tFormat
 				+ " (class cannot be evaluated)");
-			return null;
 		}
 		return tFormat;
 	}

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/function/IsEmptyFunction.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/function/IsEmptyFunction.java
@@ -16,12 +16,14 @@
 package pcgen.base.formula.function;
 
 import java.util.Arrays;
+import java.util.Optional;
 
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.DependencyManager;
 import pcgen.base.formula.base.EvaluationManager;
 import pcgen.base.formula.base.FormulaFunction;
 import pcgen.base.formula.base.FormulaSemantics;
+import pcgen.base.formula.exception.SemanticsFailureException;
 import pcgen.base.formula.parse.Node;
 import pcgen.base.formula.visitor.DependencyVisitor;
 import pcgen.base.formula.visitor.EvaluateVisitor;
@@ -48,26 +50,20 @@ public class IsEmptyFunction implements FormulaFunction
 		int argCount = args.length;
 		if (argCount != 1)
 		{
-			semantics.setInvalid("Function " + getFunctionName()
+			throw new SemanticsFailureException("Function " + getFunctionName()
 				+ " received incorrect # of arguments, expected: 1 got " + argCount + " "
 				+ Arrays.asList(args));
-			return null;
 		}
 		Node node = args[0];
 		@SuppressWarnings("PMD.PrematureDeclaration")
 		FormatManager<?> format = (FormatManager<?>) node.jjtAccept(visitor,
-			semantics.getWith(FormulaSemantics.ASSERTED, null));
-		if (!semantics.isValid())
-		{
-			return null;
-		}
+			semantics.getWith(FormulaSemantics.ASSERTED, Optional.empty()));
 		if (!format.getManagedClass().isArray())
 		{
-			semantics.setInvalid("Parse Error: Invalid Value Format: "
+			throw new SemanticsFailureException("Parse Error: Invalid Value Format: "
 				+ format.getIdentifierType() + " found in " + node.getClass().getName()
 				+ " found in location requiring an "
 				+ "ARRAY (class cannot be evaluated)");
-			return null;
 		}
 		return FormatUtilities.BOOLEAN_MANAGER;
 	}

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/function/ValueFunction.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/function/ValueFunction.java
@@ -18,11 +18,13 @@
 package pcgen.base.formula.function;
 
 import java.util.Arrays;
+import java.util.Optional;
 
 import pcgen.base.formula.base.DependencyManager;
 import pcgen.base.formula.base.EvaluationManager;
-import pcgen.base.formula.base.FormulaSemantics;
 import pcgen.base.formula.base.FormulaFunction;
+import pcgen.base.formula.base.FormulaSemantics;
+import pcgen.base.formula.exception.SemanticsFailureException;
 import pcgen.base.formula.parse.Node;
 import pcgen.base.formula.visitor.DependencyVisitor;
 import pcgen.base.formula.visitor.EvaluateVisitor;
@@ -59,12 +61,18 @@ public class ValueFunction implements FormulaFunction
 	{
 		if (args.length == 0)
 		{
-			return semantics.get(FormulaSemantics.INPUT_FORMAT);
+			Optional<FormatManager<?>> inputFormat =
+					semantics.get(FormulaSemantics.INPUT_FORMAT);
+			if (!inputFormat.isPresent())
+			{
+				throw new SemanticsFailureException("Function value()"
+					+ " unable to proceed without a known INPUT_FORMAT");
+			}
+			return inputFormat.get();
 		}
-		semantics.setInvalid("Function " + "value()"
-			+ " received incorrect # of arguments, expected: 0 got "
-			+ args.length + " " + Arrays.asList(args));
-		return null;
+		throw new SemanticsFailureException("Function " + "value()"
+			+ " received incorrect # of arguments, expected: 0 got " + args.length + " "
+			+ Arrays.asList(args));
 	}
 
 	@Override

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/inst/ComplexNEPFormula.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/inst/ComplexNEPFormula.java
@@ -24,6 +24,8 @@ import java.util.Optional;
 import pcgen.base.formula.base.DependencyManager;
 import pcgen.base.formula.base.EvaluationManager;
 import pcgen.base.formula.base.FormulaSemantics;
+import pcgen.base.formula.exception.SemanticsException;
+import pcgen.base.formula.exception.SemanticsFailureException;
 import pcgen.base.formula.parse.FormulaParser;
 import pcgen.base.formula.parse.ParseException;
 import pcgen.base.formula.parse.SimpleNode;
@@ -164,23 +166,24 @@ public class ComplexNEPFormula<T> implements NEPFormula<T>
 	}
 
 	@Override
-	public void isValid(FormulaSemantics semantics)
+	public void isValid(FormulaSemantics semantics) throws SemanticsException
 	{
-		semantics.resetReport();
-		@SuppressWarnings("PMD.PrematureDeclaration")
-		FormatManager<?> formulaFormat =
-				(FormatManager<?>) SEMANTICS_VISITOR.visit(root, semantics);
-		if (!semantics.isValid())
+		try
 		{
-			return;
+			FormatManager<?> formulaFormat =
+					(FormatManager<?>) SEMANTICS_VISITOR.visit(root, semantics);
+			if (!formatManager.equals(formulaFormat))
+			{
+				throw new SemanticsException("Parse Error: Invalid Value Format: "
+						+ formulaFormat + " found in " + root.getClass().getName()
+						+ " found in location requiring a "
+						+ formatManager.getManagedClass()
+						+ " (class cannot be evaluated)");
+			}
 		}
-		if (!formatManager.equals(formulaFormat))
+		catch (SemanticsFailureException e)
 		{
-			semantics.setInvalid("Parse Error: Invalid Value Format: "
-				+ formulaFormat + " found in " + root.getClass().getName()
-				+ " found in location requiring a "
-				+ formatManager.getManagedClass()
-				+ " (class cannot be evaluated)");
+			throw new SemanticsException(e);
 		}
 	}
 

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/inst/NEPFormula.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/inst/NEPFormula.java
@@ -20,6 +20,7 @@ package pcgen.base.formula.inst;
 import pcgen.base.formula.base.DependencyManager;
 import pcgen.base.formula.base.EvaluationManager;
 import pcgen.base.formula.base.FormulaSemantics;
+import pcgen.base.formula.exception.SemanticsException;
 import pcgen.base.util.FormatManager;
 
 /**
@@ -69,8 +70,10 @@ public interface NEPFormula<T>
 	 * @param semantics
 	 *            The FormulaSemantics object used to contain and store semantic
 	 *            information about the NEPFormula
+	 * @throws SemanticsException
+	 *             if there is an error indicating the formula is not valid
 	 */
-	public void isValid(FormulaSemantics semantics);
+	public void isValid(FormulaSemantics semantics) throws SemanticsException;
 
 	/**
 	 * Determines the dependencies for this formula, including the VariableID

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/library/ArgFunction.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/library/ArgFunction.java
@@ -24,9 +24,10 @@ import java.util.Optional;
 import pcgen.base.formula.analysis.ArgumentDependencyManager;
 import pcgen.base.formula.base.DependencyManager;
 import pcgen.base.formula.base.EvaluationManager;
+import pcgen.base.formula.base.FormulaFunction;
 import pcgen.base.formula.base.FormulaSemantics;
 import pcgen.base.formula.base.FunctionLibrary;
-import pcgen.base.formula.base.FormulaFunction;
+import pcgen.base.formula.exception.SemanticsFailureException;
 import pcgen.base.formula.parse.ASTNum;
 import pcgen.base.formula.parse.Node;
 import pcgen.base.formula.parse.SimpleNode;
@@ -89,24 +90,21 @@ public final class ArgFunction implements FormulaFunction
 	 * {@inheritDoc}
 	 */
 	@Override
-	public FormatManager<?> allowArgs(SemanticsVisitor visitor,
-		Node[] args, FormulaSemantics semantics)
+	public FormatManager<?> allowArgs(SemanticsVisitor visitor, Node[] args,
+		FormulaSemantics semantics)
 	{
 		if (args.length != 1)
 		{
-			semantics.setInvalid("Function " + FUNCTION_NAME
-				+ " received incorrect # of arguments, expected: 0 got "
-				+ args.length + " " + Arrays.asList(args));
-			return null;
+			throw new SemanticsFailureException("Function " + FUNCTION_NAME
+				+ " received incorrect # of arguments, expected: 0 got " + args.length
+				+ " " + Arrays.asList(args));
 		}
 		Node node = args[0];
 		if (!(node instanceof ASTNum))
 		{
-			semantics.setInvalid("Parse Error: Function " + FUNCTION_NAME
-				+ " received invalid argument format,"
-				+ " expected: ASTNum got " + node.getClass().getName() + ": "
-				+ node);
-			return null;
+			throw new SemanticsFailureException("Parse Error: Function " + FUNCTION_NAME
+				+ " received invalid argument format," + " expected: ASTNum got "
+				+ node.getClass().getName() + ": " + node);
 		}
 		String nodeText = ((ASTNum) node).getText();
 		try
@@ -114,11 +112,9 @@ public final class ArgFunction implements FormulaFunction
 			int argNum = Integer.parseInt(nodeText);
 			if ((argNum < 0) || (argNum >= masterArgs.length))
 			{
-				semantics.setInvalid("Function " + FUNCTION_NAME
-					+ " received incorrect # of arguments, expected: "
-					+ (argNum + 1) + " got " + masterArgs.length + " "
-					+ Arrays.asList(masterArgs));
-				return null;
+				throw new SemanticsFailureException("Function " + FUNCTION_NAME
+					+ " received incorrect # of arguments, expected: " + (argNum + 1)
+					+ " got " + masterArgs.length + " " + Arrays.asList(masterArgs));
 			}
 			assertArgs(semantics, argNum);
 			Node n = masterArgs[argNum];
@@ -126,10 +122,9 @@ public final class ArgFunction implements FormulaFunction
 		}
 		catch (NumberFormatException e)
 		{
-			semantics.setInvalid("Parse Error: Invalid Class: "
-				+ node.getClass().getName()
-				+ " found in operable location (class cannot be evaluated)");
-			return null;
+			throw new SemanticsFailureException(
+				"Parse Error: Invalid Class: " + node.getClass().getName()
+					+ " found in operable location (class cannot be evaluated)", e);
 		}
 	}
 

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/library/GenericFunction.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/library/GenericFunction.java
@@ -28,6 +28,7 @@ import pcgen.base.formula.base.FormulaFunction;
 import pcgen.base.formula.base.FormulaManager;
 import pcgen.base.formula.base.FormulaSemantics;
 import pcgen.base.formula.base.FunctionLibrary;
+import pcgen.base.formula.exception.SemanticsFailureException;
 import pcgen.base.formula.parse.Node;
 import pcgen.base.formula.parse.SimpleNode;
 import pcgen.base.formula.visitor.DependencyVisitor;
@@ -114,10 +115,9 @@ public class GenericFunction implements FormulaFunction
 		int maxArg = myArgs.getMaximumArgument() + 1;
 		if (maxArg != args.length)
 		{
-			semantics.setInvalid("Function " + functionName + " required: " + maxArg
-				+ " arguments, but was provided " + args.length + " "
+			throw new SemanticsFailureException("Function " + functionName + " required: "
+				+ maxArg + " arguments, but was provided " + args.length + " "
 				+ Arrays.asList(args));
-			return null;
 		}
 		return result;
 	}

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/ValueFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/ValueFunctionTest.java
@@ -17,11 +17,11 @@
  */
 package pcgen.base.formula.function;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import org.junit.Test;
 
-import junit.framework.TestCase;
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.EvaluationManager;
 import pcgen.base.formula.base.FormulaSemantics;
@@ -30,6 +30,7 @@ import pcgen.base.formula.visitor.ReconstructionVisitor;
 import pcgen.base.formula.visitor.SemanticsVisitor;
 import pcgen.base.testsupport.AbstractFormulaTestCase;
 import pcgen.base.testsupport.TestUtilities;
+import pcgen.base.util.FormatManager;
 
 public class ValueFunctionTest extends AbstractFormulaTestCase
 {
@@ -47,7 +48,16 @@ public class ValueFunctionTest extends AbstractFormulaTestCase
 	{
 		String formula = "value()";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
+		Optional<FormatManager<?>> assertedFormat = Optional.empty();
+		Objects.requireNonNull(assertedFormat);
+		//My isValid due to need to set INPUT_FORMAT
+		SemanticsVisitor semanticsVisitor = new SemanticsVisitor();
+		FormulaSemantics semantics = getManagerFactory()
+			.generateFormulaSemantics(getFormulaManager(), getInstanceFactory().getScope("Global"));
+		semantics = semantics.getWith(FormulaSemantics.INPUT_FORMAT,
+			Optional.of(FormatUtilities.NUMBER_MANAGER));
+		semanticsVisitor.visit(node, semantics);
+		//end my isValid
 		isStatic(formula, node, false);
 		EvaluationManager manager = generateManager().getWith(EvaluationManager.INPUT, 1);
 		performEvaluation(FormatUtilities.NUMBER_MANAGER, formula, node, Integer.valueOf(1), manager);
@@ -67,13 +77,8 @@ public class ValueFunctionTest extends AbstractFormulaTestCase
 		FormulaSemantics semantics = getManagerFactory().generateFormulaSemantics(
 			getFormulaManager(), getInstanceFactory().getScope("Global"));
 		semantics = semantics.getWith(FormulaSemantics.INPUT_FORMAT,
-			FormatUtilities.NUMBER_MANAGER);
+			Optional.of(FormatUtilities.NUMBER_MANAGER));
 		semanticsVisitor.visit(node, semantics);
-		if (!semantics.isValid())
-		{
-			TestCase.fail("Expected Valid Formula: " + formula
-				+ " but was told: " + semantics.getReport());
-		}
 		//end my isValid
 		isStatic(formula, node, false);
 		EvaluationManager manager = generateManager().getWith(EvaluationManager.INPUT, 1);

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/ComplexNEPFormulaTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/ComplexNEPFormulaTest.java
@@ -93,7 +93,6 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 		}
 		catch (SemanticsException e)
 		{
-			e.printStackTrace();
 			fail("Failed for unknown reason: " + e.getMessage());
 		}
 
@@ -118,7 +117,6 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 		}
 		catch (SemanticsException e)
 		{
-			e.printStackTrace();
 			fail(e.getMessage());
 		}
 	}

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/DynamicSolverManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/DynamicSolverManagerTest.java
@@ -348,15 +348,7 @@ public class DynamicSolverManagerTest extends AbstractSolverManagerTest
 				return null;
 			}
 
-			//If True node
-			@SuppressWarnings("PMD.PrematureDeclaration")
-			FormatManager<?> tFormat =
-					(FormatManager<?>) args[1].jjtAccept(visitor, semantics);
-			if (!semantics.isValid())
-			{
-				return null;
-			}
-			return tFormat;
+			return (FormatManager<?>) args[1].jjtAccept(visitor, semantics);
 		}
 
 		@Override

--- a/PCGen-Formula/code/src/test/pcgen/base/testsupport/AbstractFormulaTestCase.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/testsupport/AbstractFormulaTestCase.java
@@ -36,6 +36,7 @@ import pcgen.base.formula.base.VariableID;
 import pcgen.base.formula.base.VariableLibrary;
 import pcgen.base.formula.base.WriteableFunctionLibrary;
 import pcgen.base.formula.base.WriteableVariableStore;
+import pcgen.base.formula.exception.SemanticsFailureException;
 import pcgen.base.formula.inst.GlobalVarScoped;
 import pcgen.base.formula.inst.ScopeManagerInst;
 import pcgen.base.formula.inst.SimpleLegalScope;
@@ -157,11 +158,6 @@ public abstract class AbstractFormulaTestCase extends TestCase
 			getFormulaManager(), getInstanceFactory().getScope("Global"));
 		semantics = semantics.getWith(FormulaSemantics.ASSERTED, assertedFormat);
 		semanticsVisitor.visit(node, semantics);
-		if (!semantics.isValid())
-		{
-			TestCase.fail("Expected Valid Formula: " + formula + " but was told: "
-				+ semantics.getReport());
-		}
 	}
 
 	public void isStatic(String formula, SimpleNode node, boolean b)
@@ -234,10 +230,15 @@ public abstract class AbstractFormulaTestCase extends TestCase
 		FormulaSemantics semantics = managerFactory.generateFormulaSemantics(
 			getFormulaManager(), getInstanceFactory().getScope("Global"));
 		semantics = semantics.getWith(FormulaSemantics.ASSERTED, assertedFormat);
-		semanticsVisitor.visit(node, semantics);
-		if (semantics.isValid())
+		try
 		{
-			TestCase.fail("Expected Invalid Formula: " + formula + " but was valid");
+			semanticsVisitor.visit(node, semantics);
+			TestCase.fail(
+				"Expected Invalid Formula: " + formula + " but was valid");
+		}
+		catch (SemanticsFailureException e)
+		{
+			//Expected
 		}
 	}
 


### PR DESCRIPTION
Previously, a semantics check would file a report and return null to
indicate failure.

This converts that behavior to throwing an exception with the
appropriate information.