### PR TITLE
[build] remove jdepend

### DIFF
--- a/PCGen-Formula/build.gradle
+++ b/PCGen-Formula/build.gradle
@@ -15,7 +15,6 @@ plugins {
     id 'ivy-publish'
     id 'checkstyle'
     id 'pmd'
-    id 'jdepend'
 }
 
 group = 'net.sourceforge.pcgen'

--- a/PCGen-Formula/gradle/reporting.gradle
+++ b/PCGen-Formula/gradle/reporting.gradle
@@ -24,9 +24,4 @@ pmd {
 	toolVersion = "5.8.1"
 }
 
-jdepend {
-	ignoreFailures = true
-	sourceSets = []
-}
-
-task allReports { dependsOn = ['checkstyleMain', 'pmdMain', 'jdependMain'] }
+task allReports { dependsOn = ['checkstyleMain', 'pmdMain'] }


### PR DESCRIPTION
The project is unsupported and does not work with Java 11. Further the
plugin is deprecated in gradle.