### PR TITLE
[build] various improvements (spotbugs, gradle)

### DIFF
--- a/PCGen-Formula/build.gradle
+++ b/PCGen-Formula/build.gradle
@@ -9,6 +9,7 @@
  */
 
 plugins {
+    id 'com.gradle.build-scan' version '2.1'
     id "ca.coglinc2.javacc" version "3.0.0"
     id 'java'
     id 'eclipse'
@@ -17,7 +18,7 @@ plugins {
     id 'checkstyle'
     id 'pmd'
     id 'com.github.ben-manes.versions' version '0.20.0'
-    id 'com.github.spotbugs' version '1.6.5'
+    id 'com.github.spotbugs' version '1.6.9'
 }
 
 group = 'net.sourceforge.pcgen'
@@ -46,9 +47,9 @@ dependencies {
     // Use this if you want to reference your own local pcgen base, alter the 
     // relative path to what you need.
     //compile files("../../pcgen-base/PCGen-base/build/libs/PCgen-base-1.0.jar")
-    
-    compile group: 'net.sourceforge.pcgen', name: 'PCGen-base', version:'1.0.170'
-    testCompile group: 'junit', name: 'junit', version: '4.+'
+
+    implementation group: 'net.sourceforge.pcgen', name: 'PCGen-base', version:'1.0.170'
+    testImplementation group: 'junit', name: 'junit', version: '4.+'
 }
 
 sourceSets {
@@ -85,9 +86,9 @@ jacocoTestReport {
     }
 
     afterEvaluate {
-        classDirectories = files(classDirectories.files.collect {
+        getClassDirectories().from(files(classDirectories.files.collect {
             fileTree(dir: it, exclude: ['**/testsupport/**', '**/Abstract**TestCase', '**/**Test', 'pcgen/base/formula/parse/FormulaParser**', 'pcgen/base/formula/parse/AST**', 'pcgen/base/formula/parse/JJT**', 'pcgen/base/formula/parse/Node**', 'pcgen/base/formula/parse/ParseException**', 'pcgen/base/formula/parse/SimpleCharStream**', 'pcgen/base/formula/parse/Token**'])
-        })
+        }))
     }
 }
 

--- a/PCGen-Formula/gradle/reporting.gradle
+++ b/PCGen-Formula/gradle/reporting.gradle
@@ -4,8 +4,6 @@
  * called from the main build.gradle file.
  *
  * Usage: gradle allReports
- * 
- * Author: James Dempsey 
  */
 
 checkstyle {
@@ -38,6 +36,11 @@ tasks.withType(SpotBugsTask) {
         xml.enabled = false
         html.enabled = true
     }
+}
+
+buildScan {
+        termsOfServiceUrl = 'https://gradle.com/terms-of-service';
+        termsOfServiceAgree = 'yes'
 }
 
 task allReports { dependsOn = ['checkstyleMain', 'pmdMain', 'spotbugsMain'] }

--- a/PCGen-Formula/gradle/wrapper/gradle-wrapper.properties
+++ b/PCGen-Formula/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dist
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
- update spotbugs plugin to 1.6.9
- update gradle to 5.1.1
- avoid deprecated call to jacoco function
- use modern scope names (note that 'implementation' _hides_ API items.
	I need to test to see if we leak pcgen-base objects.