### PR TITLE
This converts the default storage from a Modifier to a Supplier

### DIFF
--- a/PCGen-Formula/code/src/java/pcgen/base/solver/FormulaSetupFactory.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/solver/FormulaSetupFactory.java
@@ -49,8 +49,8 @@ public class FormulaSetupFactory
 	/**
 	 * The ValueStore for this FormulaSetupFactory.
 	 */
-	private Supplier<ModifierValueStore> valueStoreSupplier =
-			() -> new ModifierValueStore();
+	private Supplier<SupplierValueStore> valueStoreSupplier =
+			() -> new SupplierValueStore();
 
 	/**
 	 * The LegalScopeManager for this FormulaSetupFactory.
@@ -97,7 +97,7 @@ public class FormulaSetupFactory
 	 */
 	public FormulaManager generate()
 	{
-		ModifierValueStore valueStore = valueStoreSupplier.get();
+		SupplierValueStore valueStore = valueStoreSupplier.get();
 		LegalScopeManager legalScopeManager = legalScopeManagerSupplier.get();
 		FunctionLibrary functionLibrary = functionLibrarySupplier.get();
 		OperatorLibrary operatorLibrary = operatorLibrarySupplier.get();
@@ -119,7 +119,7 @@ public class FormulaSetupFactory
 	 *            FormulaSetupFactory
 	 */
 	public void setValueStoreSupplier(
-		Supplier<ModifierValueStore> valueStoreSupplier)
+		Supplier<SupplierValueStore> valueStoreSupplier)
 	{
 		this.valueStoreSupplier = valueStoreSupplier;
 	}

--- a/PCGen-Formula/code/src/java/pcgen/base/solver/SolverFactory.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/solver/SolverFactory.java
@@ -17,6 +17,8 @@
  */
 package pcgen.base.solver;
 
+import java.util.function.Supplier;
+
 import pcgen.base.util.ComplexResult;
 import pcgen.base.util.FormatManager;
 
@@ -31,31 +33,27 @@ public interface SolverFactory
 {
 
 	/**
-	 * Adds a relationship between a Solver format and a default Modifier for that format
-	 * of Solver to this SolverFactory.
+	 * Adds a relationship between a Solver format and a default value for that format of
+	 * Solver to this SolverFactory.
 	 * 
-	 * The default Modifier MUST NOT depend on anything (it must be able to accept a null
-	 * input value to its process method). (See SetNumberModifier for an example of this)
-	 * 
-	 * The default Modifier for a format of Solver may not be redefined for a
-	 * SolverFactory. Once a given default Modifier has been established for a format of
+	 * The default value for a format of Solver may not be redefined for a
+	 * SolverFactory. Once a given default Supplier has been established for a format of
 	 * Solver, this method MUST NOT be called a second time for that format of Solver.
 	 * 
 	 * @param <T>
-	 *            The format (class) of object changed by the given Modifier
+	 *            The format (class) of object changed by the given Supplier
 	 * @param formatManager
-	 *            The FormatManager of the Solver format for which the given Modifier
-	 *            should be the default value
-	 * @param defaultModifier
-	 *            The Modifier to be used as the default Modifier for the given Solver
+	 *            The FormatManager of the Solver format for which the given Supplier
+	 *            should provide the default value
+	 * @param defaultValue
+	 *            The Supplier to be used to get the default value for the given Solver
 	 *            format
 	 * @throws IllegalArgumentException
-	 *             if either parameter is null, if the given Modifier has dependencies, or
-	 *             if the given Solver format already has a default Modifier defined for
-	 *             this SolverFactory
+	 *             If the given Solver format already has a default value defined for this
+	 *             SolverFactory
 	 */
 	public <T> void addSolverFormat(FormatManager<T> formatManager,
-		Modifier<? extends T> defaultModifier);
+		Supplier<? extends T> defaultValue);
 
 	/**
 	 * Returns a ComplexResult indicating the status of validating the defaults added to

--- a/PCGen-Formula/code/src/java/pcgen/base/solver/SupplierValueStore.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/solver/SupplierValueStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 (C) Tom Parker <thpr@users.sourceforge.net>
+ * Copyright 2019 (C) Tom Parker <thpr@users.sourceforge.net>
  * 
  * This library is free software; you can redistribute it and/or modify it under the terms
  * of the GNU Lesser General Public License as published by the Free Software Foundation;
@@ -20,80 +20,81 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import pcgen.base.util.CaseInsensitiveMap;
 import pcgen.base.util.FormatManager;
 import pcgen.base.util.ValueStore;
 
 /**
- * A ModifierValueStore is a centralized location to define a shared default value for a
+ * A SupplierValueStore is a centralized location to define a shared default value for a
  * format of formats for Solvers.
  */
-public class ModifierValueStore implements ValueStore
+public class SupplierValueStore implements ValueStore
 {
 
 	/**
-	 * The underlying Map for this ModifierValueStore that stores the default values by
+	 * The underlying Map for this SupplierValueStore that stores the default values by
 	 * their FormatManager.
 	 */
-	private final Map<FormatManager<?>, Modifier<?>> defaultModifierMap =
-			new HashMap<FormatManager<?>, Modifier<?>>();
+	private final Map<FormatManager<?>, Supplier<?>> formatMap =
+			new HashMap<>();
 
 	/**
-	 * The underlying Map for this ModifierValueStore that stores the default values by
+	 * The underlying Map for this SupplierValueStore that stores the default values by
 	 * their identifier.
 	 */
-	private final CaseInsensitiveMap<Modifier<?>> identifierMap =
+	private final CaseInsensitiveMap<Supplier<?>> identifierMap =
 			new CaseInsensitiveMap<>();
 
 	/**
-	 * Adds a new modifier to this ValueStore for the given FormatManager.
+	 * Adds a new default value to this SupplierValueStore for the given FormatManager.
 	 * 
 	 * @param formatManager
 	 *            The FormatManager for which the given value should be added
-	 * @param modifier
-	 *            The Modifier used to set the value for the given Identifier
-	 * @return The previous modifier for the given FormatManager, if any
+	 * @param defaultValue
+	 *            The Supplier that used to set the value for the given FormatManager
+	 * @return The previous default for the given FormatManager, if any
 	 */
 	public Object addValueFor(FormatManager<?> formatManager,
-		Modifier<?> modifier)
+		Supplier<?> defaultValue)
 	{
-		identifierMap.put(formatManager.getIdentifierType(), modifier);
-		return defaultModifierMap.put(formatManager, modifier);
+		identifierMap.put(formatManager.getIdentifierType(), defaultValue);
+		return formatMap.put(formatManager, defaultValue);
 	}
 
 	@Override
 	public Object getValueFor(String identifier)
 	{
-		Modifier<?> defaultModifier = identifierMap.get(identifier);
-		Objects.requireNonNull(defaultModifier,
+		Supplier<?> defaultValue = identifierMap.get(identifier);
+		Objects.requireNonNull(defaultValue,
 			() -> "ModifierValueStore did not have a default value for: "
 				+ identifier);
-		return defaultModifier.process(null);
+		return defaultValue.get();
 	}
 
 	/**
-	 * Returns the default Modifier (unresolved) for the given FormatManager.
+	 * Returns the default value (unresolved) for the given FormatManager.
 	 * 
 	 * @param formatManager
-	 *            The FormatManager for which the default Modifier should be returned
-	 * @return The default Modifier for the given FormatManager
+	 *            The FormatManager for which the default value should be returned
+	 * @return The (unresolved) default value for the given FormatManager
 	 */
 	@SuppressWarnings("unchecked")
-	public <T> Modifier<T> get(FormatManager<T> formatManager)
+	public <T> Supplier<T> get(FormatManager<T> formatManager)
 	{
-		return (Modifier<T>) defaultModifierMap.get(formatManager);
+		return (Supplier<T>) formatMap.get(formatManager);
 	}
 
 	/**
 	 * Returns a Set of the FormatManager objects representing the formats for which this
-	 * MidifierValueStore has a default value.
+	 * SupplierValueStore has a default value.
 	 * 
 	 * @return A Set of the FormatManager objects representing the formats for which this
-	 *         MidifierValueStore has a default value
+	 *         SupplierValueStore has a default value
 	 */
 	public Set<FormatManager<?>> getStoredFormats()
 	{
-		return Collections.unmodifiableSet(defaultModifierMap.keySet());
+		return Collections.unmodifiableSet(formatMap.keySet());
 	}
 }

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleFormulaManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleFormulaManagerTest.java
@@ -23,10 +23,9 @@ import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.FormulaManager;
 import pcgen.base.formula.base.ScopeInstanceFactory;
 import pcgen.base.formula.base.VariableLibrary;
-import pcgen.base.solver.ModifierValueStore;
 import pcgen.base.solver.SimpleSolverFactory;
 import pcgen.base.solver.SolverFactory;
-import pcgen.base.solver.testsupport.AbstractModifier;
+import pcgen.base.solver.SupplierValueStore;
 
 public class SimpleFormulaManagerTest extends TestCase
 {
@@ -36,21 +35,21 @@ public class SimpleFormulaManagerTest extends TestCase
 	private SimpleVariableStore resultsStore;
 	private SolverFactory defaultStore;
 	private ScopeInstanceFactory siFactory;
-	private ModifierValueStore valueStore;
+	private SupplierValueStore valueStore;
 
 	@Override
 	protected void setUp() throws Exception
 	{
 		super.setUp();
-		valueStore = new ModifierValueStore();
+		valueStore = new SupplierValueStore();
 		defaultStore = new SimpleSolverFactory(valueStore);
 		LegalScopeManager legalScopeManager = new ScopeManagerInst();
 		variableLibrary = new VariableManager(legalScopeManager, valueStore);
 		opLibrary = new SimpleOperatorLibrary();
 		resultsStore = new SimpleVariableStore();
 		siFactory = new SimpleScopeInstanceFactory(legalScopeManager);
-		defaultStore.addSolverFormat(FormatUtilities.NUMBER_MANAGER, AbstractModifier.setNumber(0, 0));
-		defaultStore.addSolverFormat(FormatUtilities.STRING_MANAGER, AbstractModifier.setString(""));
+		defaultStore.addSolverFormat(FormatUtilities.NUMBER_MANAGER, () -> 0);
+		defaultStore.addSolverFormat(FormatUtilities.STRING_MANAGER, () -> "");
 	}
 
 	@SuppressWarnings("unused")

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/VariableManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/VariableManagerTest.java
@@ -36,8 +36,7 @@ import pcgen.base.formula.base.VariableLibrary;
 import pcgen.base.formula.exception.LegalVariableException;
 import pcgen.base.math.OrderedPair;
 import pcgen.base.solver.Modifier;
-import pcgen.base.solver.ModifierValueStore;
-import pcgen.base.solver.testsupport.AbstractModifier;
+import pcgen.base.solver.SupplierValueStore;
 import pcgen.base.testsupport.SimpleVarScoped;
 import pcgen.base.util.FormatManager;
 import pcgen.base.util.Indirect;
@@ -50,21 +49,18 @@ public class VariableManagerTest extends TestCase
 	private ScopeInstanceFactory instanceFactory;
 	private ScopeManagerInst legalScopeManager;
 	private VariableLibrary variableLibrary;
-	private ModifierValueStore valueStore;
+	private SupplierValueStore valueStore;
 
 	@Override
 	protected void setUp() throws Exception
 	{
 		super.setUp();
-		valueStore = new ModifierValueStore();
+		valueStore = new SupplierValueStore();
 		legalScopeManager = new ScopeManagerInst();
 		instanceFactory = new SimpleScopeInstanceFactory(legalScopeManager);
-		valueStore.addValueFor(FormatUtilities.NUMBER_MANAGER,
-			AbstractModifier.setNumber(0, 0));
-		valueStore.addValueFor(FormatUtilities.STRING_MANAGER,
-			AbstractModifier.setString(""));
-		valueStore.addValueFor(FormatUtilities.BOOLEAN_MANAGER, AbstractModifier
-			.setObject(FormatUtilities.BOOLEAN_MANAGER, Boolean.FALSE, 0));
+		valueStore.addValueFor(FormatUtilities.NUMBER_MANAGER, () -> 0);
+		valueStore.addValueFor(FormatUtilities.STRING_MANAGER, () -> "");
+		valueStore.addValueFor(FormatUtilities.BOOLEAN_MANAGER, () -> false);
 		variableLibrary = new VariableManager(legalScopeManager, valueStore);
 	}
 
@@ -551,8 +547,7 @@ public class VariableManagerTest extends TestCase
 		SimpleLegalScope globalScope = new SimpleLegalScope("Global");
 		legalScopeManager.registerScope(globalScope);
 		DeferredIndirect def = new DeferredIndirect();
-		valueStore.addValueFor(FormatUtilities.ORDEREDPAIR_MANAGER,
-			new IndirectModifier<>(FormatUtilities.ORDEREDPAIR_MANAGER, def));
+		valueStore.addValueFor(FormatUtilities.ORDEREDPAIR_MANAGER, def);
 		variableLibrary.assertLegalVariableID("Walk", globalScope,
 			FormatUtilities.ORDEREDPAIR_MANAGER);
 		assertFalse(variableLibrary.getInvalidFormats().isEmpty());

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/DynamicSolverManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/DynamicSolverManagerTest.java
@@ -67,44 +67,8 @@ public class DynamicSolverManagerTest extends AbstractSolverManagerTest
 		manager = new DynamicSolverManager(getFormulaManager(), managerFactory,
 			getSolverFactory(), getVariableStore());
 		limbManager = new LimbManager();
-		getSolverFactory().addSolverFormat(limbManager, new Modifier<Limb>()
-		{
-
-			@Override
-			public Limb process(EvaluationManager evaluationManager)
-			{
-				return limbManager.convert("Head");
-			}
-
-			@Override
-			public void getDependencies(DependencyManager dependencyManager)
-			{
-			}
-
-			@Override
-			public long getPriority()
-			{
-				return 0;
-			}
-
-			@Override
-			public FormatManager<Limb> getVariableFormat()
-			{
-				return limbManager;
-			}
-
-			@Override
-			public String getIdentification()
-			{
-				return "SET";
-			}
-
-			@Override
-			public String getInstructions()
-			{
-				return "<null>";
-			}
-		});
+		getSolverFactory().addSolverFormat(limbManager,
+			() -> limbManager.convert("Head"));
 	}
 
 	@SuppressWarnings("unused")

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/testsupport/AbstractSolverManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/testsupport/AbstractSolverManagerTest.java
@@ -53,7 +53,6 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 		store = getVariableStore();
 		globalScope = getInstanceFactory().getScope("Global");
 		globalScopeInst = getGlobalScopeInst();
-		solverFactory.addSolverFormat(FormatUtilities.NUMBER_MANAGER, AbstractModifier.setNumber(0, 0));
 	}
 
 	protected abstract SolverManager getManager();

--- a/PCGen-Formula/code/src/test/pcgen/base/testsupport/AbstractFormulaTestCase.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/testsupport/AbstractFormulaTestCase.java
@@ -46,10 +46,9 @@ import pcgen.base.formula.visitor.EvaluateVisitor;
 import pcgen.base.formula.visitor.SemanticsVisitor;
 import pcgen.base.formula.visitor.StaticVisitor;
 import pcgen.base.solver.FormulaSetupFactory;
-import pcgen.base.solver.ModifierValueStore;
 import pcgen.base.solver.SimpleSolverFactory;
 import pcgen.base.solver.SolverFactory;
-import pcgen.base.solver.testsupport.AbstractModifier;
+import pcgen.base.solver.SupplierValueStore;
 import pcgen.base.util.FormatManager;
 
 public abstract class AbstractFormulaTestCase extends TestCase
@@ -59,7 +58,7 @@ public abstract class AbstractFormulaTestCase extends TestCase
 	private ScopeManagerInst legalScopeLibrary;
 	private FormulaManager formulaManager;
 	private ScopeInstance globalInstance;
-	private ModifierValueStore valueStore;
+	private SupplierValueStore valueStore;
 
 	@Override
 	protected void setUp() throws Exception
@@ -69,16 +68,15 @@ public abstract class AbstractFormulaTestCase extends TestCase
 		legalScopeLibrary = new ScopeManagerInst();
 		legalScopeLibrary.registerScope(new SimpleLegalScope("Global"));
 		setup.setLegalScopeManagerSupplier(() -> legalScopeLibrary);
-		valueStore = new ModifierValueStore();
+		valueStore = new SupplierValueStore();
 		setup.setValueStoreSupplier(() -> valueStore);
 		SolverFactory solverFactory = new SimpleSolverFactory(valueStore);
 		solverFactory.addSolverFormat(FormatUtilities.NUMBER_MANAGER,
-			AbstractModifier.setNumber(0, 0));
+			() -> 0);
 		solverFactory.addSolverFormat(FormatUtilities.STRING_MANAGER,
-			AbstractModifier.setString(""));
+			() -> "");
 		solverFactory.addSolverFormat(FormatUtilities.BOOLEAN_MANAGER,
-			AbstractModifier.setObject(FormatUtilities.BOOLEAN_MANAGER,
-				Boolean.FALSE, 0));
+			() -> false);
 		formulaManager = setup.generate();
 		globalInstance = formulaManager.getScopeInstanceFactory().get("Global",
 			Optional.of(new GlobalVarScoped("Global")));
@@ -254,7 +252,7 @@ public abstract class AbstractFormulaTestCase extends TestCase
 		return managerFactory;
 	}
 	
-	protected ModifierValueStore getValueStore()
+	protected SupplierValueStore getValueStore()
 	{
 		return valueStore;
 	}


### PR DESCRIPTION
In general, a Modifier has high overhead. (DynamicSolverManagerTest.java shows how useful this simplification is).

The older process also suffers from issues later in PCGen around how Modifier objects are constructed, which is an especially onerous process given that we have Supplier objects running around already... so this is a valuable simplification.