### PR TITLE
Extract Related Calculation

### DIFF
--- a/PCGen-Formula/code/src/java/pcgen/base/formula/base/LegalScope.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/base/LegalScope.java
@@ -17,6 +17,8 @@
  */
 package pcgen.base.formula.base;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -88,6 +90,19 @@ public interface LegalScope
 			current = current.get().getParentScope();
 		}
 		return sb.toString();
+	}
+
+	public static List<String> getHierarchy(LegalScope legalScope)
+	{
+		List<String> list = new ArrayList<>(6);
+		list.add(legalScope.getName());
+		Optional<? extends LegalScope> current = legalScope.getParentScope();
+		while (current.isPresent())
+		{
+			list.add(0, current.get().getName());
+			current = current.get().getParentScope();
+		}
+		return list;
 	}
 
 }

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/base/VariableLibrary.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/base/VariableLibrary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 (C) Tom Parker <thpr@users.sourceforge.net>
+ * Copyright 2014-20 (C) Tom Parker <thpr@users.sourceforge.net>
  * 
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -26,6 +26,9 @@ import pcgen.base.util.FormatManager;
  * VariableLibrary performs the management of legal variable names within a LegalScope.
  * This ensures that when a VariableID is built, it is in an appropriate structure to be
  * evaluated.
+ * 
+ * A VariableLibrary should ensure uniqueness of variable names when in a given
+ * scope. @see LegalScopeManager to understand how scopes can be related.
  */
 public interface VariableLibrary
 {
@@ -39,7 +42,9 @@ public interface VariableLibrary
 	 * stored as the definition for the given variable name.
 	 * 
 	 * If a previous FormatManager exists for the given variable name, then this will pass
-	 * if and only if the given LegalScope is equal to the already stored LegalScope.
+	 * if and only if the given LegalScope can allow a duplicate variable name to any
+	 * already stored LegalScope. In effect, if the scopes are at all related, then this
+	 * will fail.
 	 * 
 	 * @param varName
 	 *            The variable name for which the given FormatManager and LegalScope is

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/inst/LegalScopeManager.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/inst/LegalScopeManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 (C) Tom Parker <thpr@users.sourceforge.net>
+ * Copyright 2015-20 (C) Tom Parker <thpr@users.sourceforge.net>
  * 
  * This library is free software; you can redistribute it and/or modify it under the terms
  * of the GNU Lesser General Public License as published by the Free Software Foundation;
@@ -28,6 +28,14 @@ import pcgen.base.formula.base.LegalScopeLibrary;
  * Note: If a complete set of LegalScope objects is not loaded (meaning some of the
  * parents are not themselves loaded), then certain behaviors (like getScope) are not
  * guaranteed to properly behave.
+ * 
+ * Relationship between two LegalScope objects extends to this form of ambiguity: When
+ * in a known scope, a variable name should be unique (regardless of being in the local
+ * scope or implied from a parent scope).
+ * 
+ * If a variable name is defined for an existing parent or child (both recursively) of a
+ * LegalScope, then adding that variable name to that LegalScope should be prohibited.
+ * Otherwise, ambiguity (1) above would be violated.
  */
 public interface LegalScopeManager extends LegalScopeLibrary
 {
@@ -59,4 +67,17 @@ public interface LegalScopeManager extends LegalScopeLibrary
 	 *         false otherwise
 	 */
 	public boolean recognizesScope(LegalScope legalScope);
+	
+	/**
+	 * Returns true if two scopes are related. They are related if the presence of a
+	 * matching variable name would produce an ambiguity (as described in the description
+	 * of this interface).
+	 * 
+	 * @param firstScope
+	 *            The first scope to be checked
+	 * @param secondScope
+	 *            The second scope to be checked
+	 * @return true if the two LegalScope objects are related; false otherwise
+	 */
+	public boolean isRelated(LegalScope firstScope, LegalScope secondScope);
 }

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/inst/ScopeManagerInst.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/inst/ScopeManagerInst.java
@@ -17,6 +17,7 @@ package pcgen.base.formula.inst;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -109,5 +110,28 @@ public class ScopeManagerInst implements LegalScopeManager
 	public boolean recognizesScope(LegalScope legalScope)
 	{
 		return scopes.values().contains(legalScope);
+	}
+
+	@Override
+	public boolean isRelated(LegalScope scope1, LegalScope scope2)
+	{
+		Collection<LegalScope> descendents1 = getDescendents(scope1);
+		descendents1.retainAll(getDescendents(scope2));
+		return !descendents1.isEmpty();
+	}
+
+	private Collection<LegalScope> getDescendents(LegalScope scope)
+	{
+		Collection<LegalScope> descendents = new HashSet<LegalScope>();
+		descendents.add(scope);
+		accumulateDescendents(scope, descendents);
+		return descendents;
+	}
+
+	private void accumulateDescendents(LegalScope scope,
+		Collection<LegalScope> descendents)
+	{
+		scopeChildren.getSafeListFor(scope).stream().filter(descendents::add)
+			.forEach(child -> accumulateDescendents(child, descendents));
 	}
 }


### PR DESCRIPTION
Moves calculating relationships into the ScopeManager, since it should be internally responsible for such information (and it will help with more complex relationships to ensure they are localized)
