### PR TITLE
Update to JUnit 5

### DIFF
--- a/PCGen-Formula/build.gradle
+++ b/PCGen-Formula/build.gradle
@@ -49,7 +49,11 @@ dependencies {
     //compile files("../../pcgen-base/PCGen-base/build/libs/PCgen-base-1.0.jar")
 
     implementation group: 'net.sourceforge.pcgen', name: 'PCGen-base', version:'1.0.205'
-    testImplementation group: 'junit', name: 'junit', version: '4.+'
+    testImplementation group: 'org.junit.platform', name: 'junit-platform-runner', version: '1.6.2'
+    testImplementation group: 'org.junit.platform', name: 'junit-platform-launcher', version: '1.6.2'
+    testImplementation group: 'org.junit.jupiter', name:  'junit-jupiter-api', version: '5.6.2'
+    testImplementation group: 'org.junit.jupiter', name:  'junit-jupiter-params', version: '5.6.2'
+    testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.6.2'
 }
 
 sourceSets {

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/base/VariableIDTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/base/VariableIDTest.java
@@ -17,110 +17,73 @@
  */
 package pcgen.base.formula.base;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import junit.framework.TestCase;
-import pcgen.base.format.NumberManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.inst.ScopeManagerInst;
 import pcgen.base.formula.inst.SimpleLegalScope;
 import pcgen.base.formula.inst.SimpleScopeInstanceFactory;
 
-public class VariableIDTest extends TestCase
+public class VariableIDTest
 {
 
-	private NumberManager numberManager = FormatUtilities.NUMBER_MANAGER;
 	private ScopeManagerInst legalScopeManager;
 	private ScopeInstanceFactory instanceFactory;
 
-	@Override
-	protected void setUp() throws Exception
+	@BeforeEach
+	void setUp()
 	{
-		super.setUp();
 		legalScopeManager = new ScopeManagerInst();
 		legalScopeManager.registerScope(new SimpleLegalScope("Global"));
 		instanceFactory = new SimpleScopeInstanceFactory(legalScopeManager);
 	}
 
-	@SuppressWarnings("unused")
+	@AfterEach
+	void tearDown()
+	{
+		legalScopeManager = null;
+		instanceFactory = null;
+	}
+
 	@Test
 	public void testDoubleConstructor()
 	{
-		try
-		{
-			new VariableID<>(null, null, null);
-			fail("nulls must be rejected");
-		}
-		catch (NullPointerException | IllegalArgumentException e)
-		{
-			//ok
-		}
+		assertThrows(NullPointerException.class, () -> new VariableID<>(null, null, null));
 		ScopeInstance globalInst = instanceFactory.getGlobalInstance("Global");
-		try
-		{
-			new VariableID<>(globalInst, numberManager, null);
-			fail("null name must be rejected");
-		}
-		catch (NullPointerException | IllegalArgumentException e)
-		{
-			//ok
-		}
-		try
-		{
-			new VariableID<>(globalInst, null, "VAR");
-			fail("null FormatManager must be rejected");
-		}
-		catch (NullPointerException | IllegalArgumentException e)
-		{
-			//ok
-		}
-		try
-		{
-			new VariableID<>(null, numberManager, "VAR");
-			fail("null scope must be rejected");
-		}
-		catch (NullPointerException | IllegalArgumentException e)
-		{
-			//ok
-		}
-		try
-		{
-			new VariableID<>(globalInst, numberManager, "");
-			fail("empty name must be rejected");
-		}
-		catch (NullPointerException | IllegalArgumentException e)
-		{
-			//ok
-		}
-		try
-		{
-			new VariableID<>(globalInst, numberManager, " test");
-			fail("padded name must be rejected");
-		}
-		catch (NullPointerException | IllegalArgumentException e)
-		{
-			//ok
-		}
+		assertThrows(NullPointerException.class, () -> new VariableID<>(globalInst, FormatUtilities.NUMBER_MANAGER, null));
+		assertThrows(NullPointerException.class, () -> new VariableID<>(globalInst, null, "VAR"));
+		assertThrows(NullPointerException.class, () -> new VariableID<>(null, FormatUtilities.NUMBER_MANAGER, "VAR"));
+		assertThrows(IllegalArgumentException.class, () -> new VariableID<>(globalInst, FormatUtilities.NUMBER_MANAGER, ""));
+		assertThrows(IllegalArgumentException.class, () -> new VariableID<>(globalInst, FormatUtilities.NUMBER_MANAGER, " test"));
 	}
 
+	@Test
 	public void testGlobal()
 	{
 		ScopeInstance globalInst = instanceFactory.getGlobalInstance("Global");
-		VariableID<Number> vid = new VariableID<>(globalInst, numberManager, "test");
+		VariableID<Number> vid = new VariableID<>(globalInst, FormatUtilities.NUMBER_MANAGER, "test");
 		assertEquals("test", vid.getName());
 		assertEquals(globalInst, vid.getScope());
 		assertEquals(Number.class, vid.getVariableFormat());
 	}
 
+	@Test
 	public void testEquals()
 	{
 		ScopeInstance globalInst = instanceFactory.getGlobalInstance("Global");
 		legalScopeManager.registerScope(new SimpleLegalScope("Global2"));
 		ScopeInstance globalInst2 = instanceFactory.getGlobalInstance("Global2");
-		VariableID<Number> vid1 = new VariableID<>(globalInst, numberManager, "test");
-		VariableID<Number> vid2 = new VariableID<>(globalInst, numberManager, "test");
-		VariableID<Number> vid3 = new VariableID<>(globalInst, numberManager, "test2");
-		VariableID<Number> vid4 = new VariableID<>(globalInst2, numberManager, "test");
+		VariableID<Number> vid1 = new VariableID<>(globalInst, FormatUtilities.NUMBER_MANAGER, "test");
+		VariableID<Number> vid2 = new VariableID<>(globalInst, FormatUtilities.NUMBER_MANAGER, "test");
+		VariableID<Number> vid3 = new VariableID<>(globalInst, FormatUtilities.NUMBER_MANAGER, "test2");
+		VariableID<Number> vid4 = new VariableID<>(globalInst2, FormatUtilities.NUMBER_MANAGER, "test");
 		assertFalse(vid1.equals(null));
 		assertFalse(vid1.equals(new Object()));
 		assertTrue(vid1.equals(vid1));
@@ -130,15 +93,16 @@ public class VariableIDTest extends TestCase
 		assertFalse(vid1.equals(vid4));
 	}
 
+	@Test
 	public void testHashCode()
 	{
 		ScopeInstance globalInst = instanceFactory.getGlobalInstance("Global");
 		legalScopeManager.registerScope(new SimpleLegalScope("Global2"));
 		ScopeInstance globalInst2 = instanceFactory.getGlobalInstance("Global2");
-		VariableID<Number> vid1 = new VariableID<>(globalInst, numberManager, "test");
-		VariableID<Number> vid2 = new VariableID<>(globalInst, numberManager, "test");
-		VariableID<Number> vid3 = new VariableID<>(globalInst, numberManager, "bummer");
-		VariableID<Number> vid4 = new VariableID<>(globalInst2, numberManager, "test");
+		VariableID<Number> vid1 = new VariableID<>(globalInst, FormatUtilities.NUMBER_MANAGER, "test");
+		VariableID<Number> vid2 = new VariableID<>(globalInst, FormatUtilities.NUMBER_MANAGER, "test");
+		VariableID<Number> vid3 = new VariableID<>(globalInst, FormatUtilities.NUMBER_MANAGER, "bummer");
+		VariableID<Number> vid4 = new VariableID<>(globalInst2, FormatUtilities.NUMBER_MANAGER, "test");
 		int hc1 = vid1.hashCode();
 		int hc2 = vid2.hashCode();
 		int hc3 = vid3.hashCode();

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/AbsFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/AbsFunctionTest.java
@@ -17,10 +17,13 @@
  */
 package pcgen.base.formula.function;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.VariableID;

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/CeilFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/CeilFunctionTest.java
@@ -17,10 +17,13 @@
  */
 package pcgen.base.formula.function;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.VariableID;

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/FloorFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/FloorFunctionTest.java
@@ -17,10 +17,13 @@
  */
 package pcgen.base.formula.function;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.VariableID;

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/IfFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/IfFunctionTest.java
@@ -17,12 +17,15 @@
  */
 package pcgen.base.formula.function;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.VariableID;

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/IsEmptyFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/IsEmptyFunctionTest.java
@@ -15,13 +15,13 @@
  */
 package pcgen.base.formula.function;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import pcgen.base.format.ArrayFormatManager;
-import pcgen.base.format.NumberManager;
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.ScopeInstance;
 import pcgen.base.formula.base.VariableID;
@@ -33,18 +33,12 @@ import pcgen.base.testsupport.TestUtilities;
 public class IsEmptyFunctionTest extends AbstractFormulaTestCase
 {
 
-	private static final Number[] EMPTY_ARR = {};
-	private static final Number[] ARR_1 = {Integer.valueOf(1)};
-
-	private ArrayFormatManager<Number> manager =
-			new ArrayFormatManager<>(new NumberManager(), '\n', ',');
-
 	@Test
 	public void testInvalidTooManyArg()
 	{
 		String formula = "isEmpty(2, 3)";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isNotValid(formula, node, manager, Optional.empty());
+		isNotValid(formula, node, TestUtilities.NUMBER_ARRAY_MANAGER, Optional.empty());
 	}
 
 	@Test
@@ -52,7 +46,7 @@ public class IsEmptyFunctionTest extends AbstractFormulaTestCase
 	{
 		String formula = "isEmpty(\"ab\")";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isNotValid(formula, node, manager, Optional.empty());
+		isNotValid(formula, node, TestUtilities.NUMBER_ARRAY_MANAGER, Optional.empty());
 	}
 
 	@Test
@@ -60,16 +54,16 @@ public class IsEmptyFunctionTest extends AbstractFormulaTestCase
 	{
 		String formula = "isEmpty(ab)";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isNotValid(formula, node, manager, Optional.empty());
+		isNotValid(formula, node, TestUtilities.NUMBER_ARRAY_MANAGER, Optional.empty());
 	}
 
 	@Test
 	public void testEmptyArrayVar()
 	{
-		getVariableStore().put(getArrayVariable("a"), EMPTY_ARR);
+		getVariableStore().put(getArrayVariable("a"), TestUtilities.EMPTY_ARRAY);
 		String formula = "isEmpty(a)";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, manager, Optional.empty());
+		isValid(formula, node, TestUtilities.NUMBER_ARRAY_MANAGER, Optional.empty());
 		isStatic(formula, node, false);
 		List<VariableID<?>> vars = getVariables(node);
 		assertEquals(1, vars.size());
@@ -81,10 +75,10 @@ public class IsEmptyFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testNotEmptyArrayVar()
 	{
-		getVariableStore().put(getArrayVariable("a"), ARR_1);
+		getVariableStore().put(getArrayVariable("a"), new Number[]{1});
 		String formula = "isEmpty(a)";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, manager, Optional.empty());
+		isValid(formula, node, TestUtilities.NUMBER_ARRAY_MANAGER, Optional.empty());
 		isStatic(formula, node, false);
 		List<VariableID<?>> vars = getVariables(node);
 		assertEquals(1, vars.size());
@@ -98,7 +92,7 @@ public class IsEmptyFunctionTest extends AbstractFormulaTestCase
 		VariableLibrary variableLibrary = getVariableLibrary();
 		ScopeInstance globalInst = getInstanceFactory().getGlobalInstance("Global");
 		variableLibrary.assertLegalVariableID(formula, globalInst.getLegalScope(),
-			manager);
+			TestUtilities.NUMBER_ARRAY_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number[]> variableID =
 				(VariableID<Number[]>) variableLibrary.getVariableID(globalInst, formula);

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/LengthFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/LengthFunctionTest.java
@@ -17,13 +17,13 @@
  */
 package pcgen.base.formula.function;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import pcgen.base.format.ArrayFormatManager;
-import pcgen.base.format.NumberManager;
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.VariableID;
 import pcgen.base.formula.base.VariableLibrary;
@@ -33,15 +33,12 @@ import pcgen.base.testsupport.TestUtilities;
 
 public class LengthFunctionTest extends AbstractFormulaTestCase
 {
-	private ArrayFormatManager<Number> manager = new ArrayFormatManager<>(
-			new NumberManager(), '\n', ',');
-
 	@Test
 	public void testInvalidTooManyArg()
 	{
 		String formula = "length(2, 3)";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isNotValid(formula, node, manager, Optional.empty());
+		isNotValid(formula, node, TestUtilities.NUMBER_ARRAY_MANAGER, Optional.empty());
 	}
 
 	@Test
@@ -49,7 +46,7 @@ public class LengthFunctionTest extends AbstractFormulaTestCase
 	{
 		String formula = "length(\"ab\")";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isNotValid(formula, node, manager, Optional.empty());
+		isNotValid(formula, node, TestUtilities.NUMBER_ARRAY_MANAGER, Optional.empty());
 	}
 
 	@Test
@@ -57,7 +54,7 @@ public class LengthFunctionTest extends AbstractFormulaTestCase
 	{
 		String formula = "length(ab)";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isNotValid(formula, node, manager, Optional.empty());
+		isNotValid(formula, node, TestUtilities.NUMBER_ARRAY_MANAGER, Optional.empty());
 	}
 
 	@Test
@@ -65,13 +62,14 @@ public class LengthFunctionTest extends AbstractFormulaTestCase
 	{
 		VariableLibrary variableLibrary = getVariableLibrary();
 		variableLibrary.assertLegalVariableID("a",
-			getInstanceFactory().getScope("Global"), manager);
+			getInstanceFactory().getScope("Global"), TestUtilities.NUMBER_ARRAY_MANAGER);
+		@SuppressWarnings("unchecked")
 		VariableID<Number[]> variable = (VariableID<Number[]>) variableLibrary
 			.getVariableID(getGlobalScopeInst(), "a");
 		getVariableStore().put(variable, new Number[]{5});
 		String formula = "length(a)";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, manager, Optional.empty());
+		isValid(formula, node, TestUtilities.NUMBER_ARRAY_MANAGER, Optional.empty());
 		isStatic(formula, node, false);
 		List<VariableID<?>> vars = getVariables(node);
 		assertEquals(1, vars.size());

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/MaxFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/MaxFunctionTest.java
@@ -17,10 +17,13 @@
  */
 package pcgen.base.formula.function;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.VariableID;

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/MinFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/MinFunctionTest.java
@@ -17,10 +17,13 @@
  */
 package pcgen.base.formula.function;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.VariableID;

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/RoundFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/RoundFunctionTest.java
@@ -17,10 +17,13 @@
  */
 package pcgen.base.formula.function;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.VariableID;

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/ValueFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/ValueFunctionTest.java
@@ -17,10 +17,12 @@
  */
 package pcgen.base.formula.function;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Objects;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.EvaluationManager;

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/ComplexNEPFormulaTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/ComplexNEPFormulaTest.java
@@ -1,60 +1,39 @@
 package pcgen.base.formula.inst;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.analysis.ArgumentDependencyManager;
 import pcgen.base.formula.base.DependencyManager;
 import pcgen.base.formula.base.EvaluationManager;
 import pcgen.base.formula.base.FormulaSemantics;
-import pcgen.base.formula.base.ManagerFactory;
 import pcgen.base.formula.base.VariableID;
 import pcgen.base.formula.base.VariableList;
 import pcgen.base.formula.exception.SemanticsException;
 import pcgen.base.testsupport.AbstractFormulaTestCase;
+import pcgen.base.testsupport.TestUtilities;
 
 public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 {
 
-	private ManagerFactory managerFactory = new ManagerFactory()
-	{
-	};
-
-	@SuppressWarnings("unused")
+	@Test
 	public void testConstructor()
 	{
-		try
-		{
-			new ComplexNEPFormula<>(null, FormatUtilities.NUMBER_MANAGER);
-			fail("Expected null formula text to fail");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
-		try
-		{
-			new ComplexNEPFormula<>("3+6", null);
-			fail("Expected null format manager to fail");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
-		try
-		{
-			new ComplexNEPFormula<>("3+*5", FormatUtilities.NUMBER_MANAGER);
-			fail("Expected bad formula text to fail");
-		}
-		catch (IllegalArgumentException e)
-		{
-			//ok
-		}
+		assertThrows(NullPointerException.class, () -> new ComplexNEPFormula<>(null, FormatUtilities.NUMBER_MANAGER));
+		assertThrows(NullPointerException.class, () -> new ComplexNEPFormula<>("3+6", null));
+		assertThrows(IllegalArgumentException.class, () -> new ComplexNEPFormula<>("3+*5", FormatUtilities.NUMBER_MANAGER));
 	}
 
+	@Test
 	public void testToString()
 	{
 		assertEquals("3+5", new ComplexNEPFormula<>("3+5", FormatUtilities.NUMBER_MANAGER).toString());
@@ -73,22 +52,11 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 			new ComplexNEPFormula<>("process[THIS]", FormatUtilities.NUMBER_MANAGER).toString());
 	}
 
+	@Test
 	public void testIsValid()
 	{
 		FormulaSemantics fs = getSemantics();
-		try
-		{
-			new ComplexNEPFormula<Number>("3+5", FormatUtilities.NUMBER_MANAGER).isValid(null);
-			fail("Expected null FormulaSemantics to fail");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
-		catch (SemanticsException e)
-		{
-			fail("Failed for unknown reason: " + e.getMessage());
-		}
+		assertThrows(NullPointerException.class, () -> new ComplexNEPFormula<Number>("3+5", FormatUtilities.NUMBER_MANAGER).isValid(null));
 
 		try {
 			new ComplexNEPFormula<Number>("3+5", FormatUtilities.NUMBER_MANAGER).isValid(fs);
@@ -115,6 +83,7 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 		}
 	}
 
+	@Test
 	public void testGetDependenciesNone()
 	{
 		DependencyManager depManager = setupDM();
@@ -127,6 +96,7 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 		assertEquals(-1, potentialArgDM.get().getMaximumArgument());
 	}
 
+	@Test
 	public void testGetDependenciesNoneToo()
 	{
 		DependencyManager depManager = setupDM();
@@ -139,6 +109,7 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 		assertEquals(-1, potentialArgDM.get().getMaximumArgument());
 	}
 
+	@Test
 	public void testGetDependenciesNoneLonger()
 	{
 		DependencyManager depManager = setupDM();
@@ -151,6 +122,7 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 		assertEquals(-1, potentialArgDM.get().getMaximumArgument());
 	}
 
+	@Test
 	public void testGetDependenciesVars()
 	{
 		getVariableLibrary().assertLegalVariableID("a",
@@ -173,6 +145,7 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 		assertEquals(-1, potentialArgDM.get().getMaximumArgument());
 	}
 
+	@Test
 	public void testGetDependenciesVarsIfOne()
 	{
 		getVariableLibrary().assertLegalVariableID("a",
@@ -194,6 +167,7 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 		assertEquals(-1, potentialArgDM.get().getMaximumArgument());
 	}
 
+	@Test
 	public void testGetDependenciesVarsIfTwo()
 	{
 		getVariableLibrary().assertLegalVariableID("a",
@@ -215,6 +189,7 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 		assertEquals(-1, potentialArgDM.get().getMaximumArgument());
 	}
 
+	@Test
 	public void testGetDependenciesVarsIfThree()
 	{
 		getVariableLibrary().assertLegalVariableID("c",
@@ -238,6 +213,7 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 		assertEquals(-1, potentialArgDM.get().getMaximumArgument());
 	}
 
+	@Test
 	public void testGetDependenciesValue()
 	{
 		DependencyManager depManager = setupDM();
@@ -253,9 +229,9 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 
 	private DependencyManager setupDM()
 	{
-		DependencyManager dm = managerFactory
+		DependencyManager dm = TestUtilities.EMPTY_MGR_FACTORY
 			.generateDependencyManager(getFormulaManager(), getGlobalScopeInst());
-		dm = managerFactory.withVariables(dm);
+		dm = TestUtilities.EMPTY_MGR_FACTORY.withVariables(dm);
 		return dm.getWith(ArgumentDependencyManager.KEY,
 			Optional.of(new ArgumentDependencyManager()));
 	}
@@ -263,15 +239,7 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 	public void testResolve()
 	{
 		EvaluationManager evalManager = generateManager();
-		try
-		{
-			new ComplexNEPFormula<>("3+5", FormatUtilities.NUMBER_MANAGER).resolve(null);
-			fail("Expected null FormulaManager to fail");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
+		assertThrows(IllegalArgumentException.class, () -> new ComplexNEPFormula<>("3+5", FormatUtilities.NUMBER_MANAGER).resolve(null));
 
 		assertEquals(8, new ComplexNEPFormula<>("3+5", FormatUtilities.NUMBER_MANAGER).resolve(evalManager));
 		assertEquals(15, new ComplexNEPFormula<>("3*5", FormatUtilities.NUMBER_MANAGER).resolve(evalManager));
@@ -320,16 +288,11 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 		ComplexNEPFormula<String> fourString = new ComplexNEPFormula<>("\"4\"", FormatUtilities.STRING_MANAGER);
 		FormulaSemantics fs = getSemantics();
 		fourString.isValid(fs);
-		try
-		{
-			fourString.isValid(fs.getWith(FormulaSemantics.ASSERTED, Optional.of(FormatUtilities.NUMBER_MANAGER)));
-			fail("Expected the Conversion to pass for the result to "
+		assertThrows(SemanticsException.class,
+			() -> fourString.isValid(fs.getWith(FormulaSemantics.ASSERTED,
+				Optional.of(FormatUtilities.NUMBER_MANAGER))),
+			"Expected the Conversion to pass for the result to "
 				+ "not be the String the ComplexNEPFormula expected!");
-		}
-		catch (SemanticsException e)
-		{
-			//Expected
-		}
 	}
 
 	@Test
@@ -339,16 +302,10 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 				new ComplexNEPFormula<>("\"4,4\"", FormatUtilities.NUMBER_MANAGER);
 
 		FormulaSemantics fs = getSemantics();
-		try
-		{
-			notANumber
-				.isValid(fs.getWith(FormulaSemantics.ASSERTED, Optional.of(FormatUtilities.NUMBER_MANAGER)));
-			fail("Expected non-number to fail");
-		}
-		catch (SemanticsException e)
-		{
-			//Expected
-		}
+		assertThrows(SemanticsException.class,
+			() -> notANumber.isValid(fs.getWith(FormulaSemantics.ASSERTED,
+				Optional.of(FormatUtilities.NUMBER_MANAGER))),
+			"Expected non-number to fail");
 	}
 
 	@Test
@@ -356,15 +313,8 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 	{
 		ComplexNEPFormula<String> fiveMismatch = new ComplexNEPFormula<>("5", FormatUtilities.STRING_MANAGER);
 		FormulaSemantics fs = getSemantics();
-		try
-		{
-			fiveMismatch.isValid(fs);
-			fail("Expected non-quoted item to fail as a String");
-		}
-		catch (SemanticsException e)
-		{
-			//Expected
-		}
+		assertThrows(SemanticsException.class, () -> fiveMismatch.isValid(fs),
+			"Expected non-quoted item to fail as a String");
 	}
 
 	@Test
@@ -373,16 +323,9 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 		ComplexNEPFormula<Number> longWayAround =
 				new ComplexNEPFormula<>("\"4\"", FormatUtilities.NUMBER_MANAGER);
 		FormulaSemantics fs = getSemantics();
-		try
-		{
-			longWayAround.isValid(fs);
-			fail("Expected quoted item to fail as a number "
+		assertThrows(SemanticsException.class, () -> longWayAround.isValid(fs),
+			"Expected quoted item to fail as a number "
 				+ "because not convertable without an assertion");
-		}
-		catch (SemanticsException e)
-		{
-			//Expected
-		}
 		longWayAround
 			.isValid(fs.getWith(FormulaSemantics.ASSERTED, Optional.of(FormatUtilities.NUMBER_MANAGER)));
 	}
@@ -399,7 +342,7 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 
 	private FormulaSemantics getSemantics()
 	{
-		return managerFactory.generateFormulaSemantics(getFormulaManager(),
+		return TestUtilities.EMPTY_MGR_FACTORY.generateFormulaSemantics(getFormulaManager(),
 			getInstanceFactory().getScope("Global"));
 	}
 }

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/FormulaUtilitiesTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/FormulaUtilitiesTest.java
@@ -17,12 +17,14 @@
  */
 package pcgen.base.formula.inst;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
+
 import pcgen.base.testsupport.TestUtilities;
 
-public class FormulaUtilitiesTest extends TestCase
+public class FormulaUtilitiesTest
 {
 
+	@Test
 	public void testDepKey()
 	{
 		TestUtilities.invokePrivateConstructor(FormulaUtilities.class);

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/ScopeManagerInstTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/ScopeManagerInstTest.java
@@ -17,16 +17,21 @@
  */
 package pcgen.base.formula.inst;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import junit.framework.TestCase;
 import pcgen.base.formula.base.LegalScope;
 
-public class ScopeManagerInstTest extends TestCase
+public class ScopeManagerInstTest
 {
 
 	private ScopeManagerInst legalScopeManager;
@@ -34,77 +39,34 @@ public class ScopeManagerInstTest extends TestCase
 	private SimpleLegalScope subScope = new SimpleLegalScope(globalScope, "SubScope");
 	private SimpleLegalScope otherScope = new SimpleLegalScope(globalScope, "OtherScope");
 
-	@Override
-	protected void setUp() throws Exception
+	@BeforeEach
+	void setUp()
 	{
-		super.setUp();
 		legalScopeManager = new ScopeManagerInst();
+	}
+	
+	@AfterEach
+	void tearDown()
+	{
+		legalScopeManager = null;
 	}
 
 	@Test
 	public void testNullRegister()
 	{
-		try
-		{
-			legalScopeManager.registerScope(null);
-			fail("null must be rejected in registerScope");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
+		assertThrows(NullPointerException.class, () -> legalScopeManager.registerScope(null));
 	}
 
 	@Test
 	public void testBadRegister()
 	{
-		try
-		{
-			legalScopeManager.registerScope(new BadLegalScope1());
-			fail("null name must be rejected in registerScope");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
-		try
-		{
-			legalScopeManager.registerScope(new BadLegalScope2());
-			fail("null parent must be rejected in registerScope");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
-		try
-		{
-			legalScopeManager.registerScope(subScope);
-			fail("should reject because parent has not been added");
-		}
-		catch (IllegalArgumentException e)
-		{
-			//ok
-		}
+		assertThrows(NullPointerException.class, () -> legalScopeManager.registerScope(new BadLegalScope1()));
+		assertThrows(NullPointerException.class, () -> legalScopeManager.registerScope(new BadLegalScope2()));
+		assertThrows(IllegalArgumentException.class, () -> legalScopeManager.registerScope(subScope));
 		legalScopeManager.registerScope(globalScope);
 		legalScopeManager.registerScope(subScope);
-		try
-		{
-			legalScopeManager.registerScope(new SimpleLegalScope(globalScope, "SubScope"));
-			fail("dupe name be rejected in registerScope");
-		}
-		catch (IllegalArgumentException e)
-		{
-			//ok
-		}
-		try
-		{
-			legalScopeManager.registerScope(new SimpleLegalScope(globalScope, "Sub.Scope"));
-			fail("dupe name be rejected in registerScope");
-		}
-		catch (IllegalArgumentException e)
-		{
-			//ok
-		}
+		assertThrows(IllegalArgumentException.class, () -> legalScopeManager.registerScope(new SimpleLegalScope(globalScope, "SubScope")));
+		assertThrows(IllegalArgumentException.class, () -> legalScopeManager.registerScope(new SimpleLegalScope(globalScope, "Sub.Scope")));
 	}
 	
 	@Test
@@ -119,15 +81,7 @@ public class ScopeManagerInstTest extends TestCase
 	@Test
 	public void testNullGet()
 	{
-		try
-		{
-			legalScopeManager.getChildScopes(null);
-			fail("null must be rejected in getChildScopes");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
+		assertThrows(NullPointerException.class, () -> legalScopeManager.getChildScopes(null));
 	}
 
 	@Test

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleFormulaManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleFormulaManagerTest.java
@@ -15,10 +15,13 @@
  */
 package pcgen.base.formula.inst;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import junit.framework.TestCase;
-import pcgen.base.format.ArrayFormatManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.FormulaManager;
 import pcgen.base.formula.base.ScopeInstanceFactory;
@@ -26,8 +29,9 @@ import pcgen.base.formula.base.VariableLibrary;
 import pcgen.base.solver.SimpleSolverFactory;
 import pcgen.base.solver.SolverFactory;
 import pcgen.base.solver.SupplierValueStore;
+import pcgen.base.testsupport.TestUtilities;
 
-public class SimpleFormulaManagerTest extends TestCase
+public class SimpleFormulaManagerTest
 {
 
 	private VariableLibrary variableLibrary;
@@ -37,10 +41,9 @@ public class SimpleFormulaManagerTest extends TestCase
 	private ScopeInstanceFactory siFactory;
 	private SupplierValueStore valueStore;
 
-	@Override
-	protected void setUp() throws Exception
+	@BeforeEach
+	void setUp()
 	{
-		super.setUp();
 		valueStore = new SupplierValueStore();
 		defaultStore = new SimpleSolverFactory(valueStore);
 		LegalScopeManager legalScopeManager = new ScopeManagerInst();
@@ -51,70 +54,27 @@ public class SimpleFormulaManagerTest extends TestCase
 		defaultStore.addSolverFormat(FormatUtilities.NUMBER_MANAGER, () -> 0);
 		defaultStore.addSolverFormat(FormatUtilities.STRING_MANAGER, () -> "");
 	}
+	
+	@AfterEach
+	void tearDown()
+	{
+		variableLibrary = null;
+		opLibrary = null;
+		resultsStore = null;
+		defaultStore = null;
+		siFactory = null;
+		valueStore = null;
+	}
 
-	@SuppressWarnings("unused")
 	@Test
 	public void testDoubleConstructor()
 	{
-		try
-		{
-			new SimpleFormulaManager(null, null, null, null, null);
-			fail("nulls must be rejected");
-		}
-		catch (NullPointerException | IllegalArgumentException e)
-		{
-			//ok
-		}
-		try
-		{
-			new SimpleFormulaManager(null, variableLibrary, siFactory,
-				resultsStore, valueStore);
-			fail("null op lib must be rejected");
-		}
-		catch (NullPointerException | IllegalArgumentException e)
-		{
-			//ok
-		}
-		try
-		{
-			new SimpleFormulaManager(opLibrary, null, siFactory, resultsStore,
-				valueStore);
-			fail("null var lib must be rejected");
-		}
-		catch (NullPointerException | IllegalArgumentException e)
-		{
-			//ok
-		}
-		try
-		{
-			new SimpleFormulaManager(opLibrary, variableLibrary, null,
-				resultsStore, valueStore);
-			fail("null var siFactory must be rejected");
-		}
-		catch (NullPointerException | IllegalArgumentException e)
-		{
-			//ok
-		}
-		try
-		{
-			new SimpleFormulaManager(opLibrary, variableLibrary, siFactory, null,
-				valueStore);
-			fail("null results must be rejected");
-		}
-		catch (NullPointerException | IllegalArgumentException e)
-		{
-			//ok
-		}
-		try
-		{
-			new SimpleFormulaManager(opLibrary, variableLibrary, siFactory,
-				resultsStore, null);
-			fail("null defaults must be rejected");
-		}
-		catch (NullPointerException | IllegalArgumentException e)
-		{
-			//ok
-		}
+		assertThrows(NullPointerException.class, () -> new SimpleFormulaManager(null, null, null, null, null));
+		assertThrows(NullPointerException.class, () -> new SimpleFormulaManager(null, variableLibrary, siFactory, resultsStore, valueStore));
+		assertThrows(NullPointerException.class, () -> new SimpleFormulaManager(opLibrary, null, siFactory, resultsStore, valueStore));
+		assertThrows(NullPointerException.class, () -> new SimpleFormulaManager(opLibrary, variableLibrary, null, resultsStore, valueStore));
+		assertThrows(NullPointerException.class, () -> new SimpleFormulaManager(opLibrary, variableLibrary, siFactory, null, valueStore));
+		assertThrows(NullPointerException.class, () -> new SimpleFormulaManager(opLibrary, variableLibrary, siFactory, resultsStore, null));
 	}
 
 	@Test
@@ -124,7 +84,7 @@ public class SimpleFormulaManagerTest extends TestCase
 			resultsStore, valueStore);
 		assertEquals(0,formulaManager.getDefault(FormatUtilities.NUMBER_MANAGER));
 		assertEquals("", formulaManager.getDefault(FormatUtilities.STRING_MANAGER));
-		Object[] array = formulaManager.getDefault(new ArrayFormatManager<>(FormatUtilities.NUMBER_MANAGER, '\n', ','));
+		Object[] array = formulaManager.getDefault(TestUtilities.NUMBER_ARRAY_MANAGER);
 		assertEquals(0, array.length);
 	}
 }

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleFunctionLibraryTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleFunctionLibraryTest.java
@@ -17,16 +17,18 @@
  */
 package pcgen.base.formula.inst;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import pcgen.base.formula.base.DependencyManager;
 import pcgen.base.formula.base.EvaluationManager;
-import pcgen.base.formula.base.FormulaSemantics;
 import pcgen.base.formula.base.FormulaFunction;
+import pcgen.base.formula.base.FormulaSemantics;
 import pcgen.base.formula.parse.Node;
 import pcgen.base.formula.visitor.DependencyVisitor;
 import pcgen.base.formula.visitor.EvaluateVisitor;
@@ -34,49 +36,27 @@ import pcgen.base.formula.visitor.SemanticsVisitor;
 import pcgen.base.formula.visitor.StaticVisitor;
 import pcgen.base.util.FormatManager;
 
-public class SimpleFunctionLibraryTest extends TestCase
+public class SimpleFunctionLibraryTest
 {
-	private SimpleFunctionLibrary library;
-
-	@Override
-	protected void setUp() throws Exception
-	{
-		super.setUp();
-		library = new SimpleFunctionLibrary();
-	}
 
 	@Test
 	public void testInvalidNull()
 	{
-		try
-		{
-			library.addFunction(null);
-			fail("Expected null function to be rejected");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//Yep
-		}
+		SimpleFunctionLibrary library = new SimpleFunctionLibrary();
+		assertThrows(NullPointerException.class, () -> library.addFunction(null));
 	}
 
 	@Test
 	public void testInvalidNullName()
 	{
-		try
-		{
-			FormulaFunction f = getPseudoFunction(null);
-			library.addFunction(f);
-			fail("Expected function with null name to be rejected");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//Yep
-		}
+		SimpleFunctionLibrary library = new SimpleFunctionLibrary();
+		assertThrows(NullPointerException.class, () -> library.addFunction(getPseudoFunction(null)));
 	}
 
 	@Test
 	public void testSimpleFunctionSetGet()
 	{
+		SimpleFunctionLibrary library = new SimpleFunctionLibrary();
 		FormulaFunction abs = getPseudoFunction("Abs");
 		library.addFunction(abs);
 		//case insensitive
@@ -88,12 +68,12 @@ public class SimpleFunctionLibraryTest extends TestCase
 	@Test
 	public void testInvalidDupeNameSimpleFunction()
 	{
+		SimpleFunctionLibrary library = new SimpleFunctionLibrary();
 		FormulaFunction abs = getPseudoFunction("Abs");
 		library.addFunction(abs);
 		try
 		{
-			FormulaFunction pseudoFunction = getPseudoFunction("ABS");
-			library.addFunction(pseudoFunction);
+			library.addFunction(getPseudoFunction("ABS"));
 			fail("Should not have been able to add function twice");
 		}
 		catch (IllegalArgumentException e)
@@ -103,8 +83,7 @@ public class SimpleFunctionLibraryTest extends TestCase
 		}
 		try
 		{
-			FormulaFunction pseudoFunction = getPseudoFunction("abs");
-			library.addFunction(pseudoFunction);
+			library.addFunction(getPseudoFunction("abs"));
 			fail("Should not have been able to add function twice, regardless of case");
 		}
 		catch (IllegalArgumentException e)

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleLegalScopeTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleLegalScopeTest.java
@@ -17,39 +17,26 @@
  */
 package pcgen.base.formula.inst;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-public class SimpleLegalScopeTest extends TestCase
+public class SimpleLegalScopeTest
 {
-
-	private SimpleLegalScope scope;
-
-	@Override
-	protected void setUp() throws Exception
-	{
-		super.setUp();
-		scope = new SimpleLegalScope("Global");
-	}
 
 	@Test
 	public void testDoubleConstructor()
 	{
-		try
-		{
-			scope = new SimpleLegalScope(scope, null);
-			fail("null name must be rejected");
-		}
-		catch (NullPointerException | IllegalArgumentException e)
-		{
-			//ok
-		}
+		SimpleLegalScope scope = new SimpleLegalScope("Global");
+		assertThrows(NullPointerException.class, () -> new SimpleLegalScope(scope, null));
 	}
 
 	@Test
 	public void testIsValid()
 	{
+		SimpleLegalScope scope = new SimpleLegalScope("Global");
 		SimpleLegalScope local = new SimpleLegalScope(scope, "Local");
 		assertTrue(local.getParentScope().isPresent());
 		assertEquals(scope, local.getParentScope().get());

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleOperatorLibraryTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleOperatorLibraryTest.java
@@ -17,10 +17,13 @@
  */
 package pcgen.base.formula.inst;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.OperatorAction;
 import pcgen.base.formula.base.UnaryAction;
 import pcgen.base.formula.operator.generic.GenericEquals;
@@ -28,113 +31,60 @@ import pcgen.base.formula.operator.number.NumberAdd;
 import pcgen.base.formula.operator.number.NumberEquals;
 import pcgen.base.formula.operator.number.NumberMinus;
 import pcgen.base.formula.parse.Operator;
+import pcgen.base.testsupport.TestUtilities;
 
-public class SimpleOperatorLibraryTest extends TestCase
+public class SimpleOperatorLibraryTest
 {
-	private static final Class<Number> NUMBER_CLASS = Number.class;
-	private static final Class<Integer> INTEGER_CLASS = Integer.class;
-
-	private SimpleOperatorLibrary library;
-
-	@Override
-	protected void setUp() throws Exception
-	{
-		super.setUp();
-		library = new SimpleOperatorLibrary();
-	}
 
 	@Test
 	public void testInvalidNull()
 	{
-		try
-		{
-			library.addAction((OperatorAction) null);
-			fail("Expected null action to be rejected");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//Yep
-		}
-		try
-		{
-			library.addAction((UnaryAction) null);
-			fail("Expected null action to be rejected");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//Yep
-		}
+		SimpleOperatorLibrary library = new SimpleOperatorLibrary();
+		assertThrows(NullPointerException.class, () -> library.addAction((OperatorAction) null));
+		assertThrows(NullPointerException.class, () -> library.addAction((UnaryAction) null));
 	}
 
 	@Test
 	public void testEmpty()
 	{
+		SimpleOperatorLibrary library = new SimpleOperatorLibrary();
 		assertTrue(
-			library.processAbstract(Operator.ADD, NUMBER_CLASS, INTEGER_CLASS, null).isEmpty());
-		assertTrue(library.processAbstract(Operator.MINUS, NUMBER_CLASS).isEmpty());
-		try
-		{
-			library.evaluate(Operator.ADD, 1, 2, null);
-			fail();
-		}
-		catch (IllegalStateException e)
-		{
-			//Wasn't defined yet
-		}
-		try
-		{
-			library.evaluate(Operator.MINUS, 1);
-			fail();
-		}
-		catch (IllegalStateException e)
-		{
-			//Wasn't defined yet
-		}
+			library.processAbstract(Operator.ADD, FormatUtilities.NUMBER_CLASS, TestUtilities.INTEGER_CLASS, null).isEmpty());
+		assertTrue(library.processAbstract(Operator.MINUS, FormatUtilities.NUMBER_CLASS).isEmpty());
+		assertThrows(IllegalStateException.class, () -> library.evaluate(Operator.ADD, 1, 2, null));
+		assertThrows(IllegalStateException.class, () -> library.evaluate(Operator.MINUS, 1));
 	}
 
 	@Test
 	public void testSimpleBinary()
 	{
+		SimpleOperatorLibrary library = new SimpleOperatorLibrary();
 		library.addAction(new NumberAdd());
 		assertEquals(Number.class,
-			library.processAbstract(Operator.ADD, NUMBER_CLASS, INTEGER_CLASS, null).get().getManagedClass());
+			library.processAbstract(Operator.ADD, FormatUtilities.NUMBER_CLASS, TestUtilities.INTEGER_CLASS, null).get().getManagedClass());
 		assertEquals(Integer.valueOf(3), library.evaluate(Operator.ADD, 1, 2, null));
-		try
-		{
-			library.evaluate(Operator.ADD, true, false, null);
-			fail();
-		}
-		catch (IllegalStateException e)
-		{
-			//Isn't defined 
-		}
+		assertThrows(IllegalStateException.class, () -> library.evaluate(Operator.ADD, true, false, null));
 	}
 
 	@Test
 	public void testSimpleUnary()
 	{
+		SimpleOperatorLibrary library = new SimpleOperatorLibrary();
 		library.addAction(new NumberMinus());
 		assertEquals(Number.class,
-			library.processAbstract(Operator.MINUS, INTEGER_CLASS).get().getManagedClass());
+			library.processAbstract(Operator.MINUS, TestUtilities.INTEGER_CLASS).get().getManagedClass());
 		assertEquals(Integer.valueOf(3), library.evaluate(Operator.MINUS, -3));
-		try
-		{
-			library.evaluate(Operator.MINUS, true);
-			fail();
-		}
-		catch (IllegalStateException e)
-		{
-			//Isn't defined 
-		}
+		assertThrows(IllegalStateException.class, () -> library.evaluate(Operator.MINUS, true));
 	}
 
 	@Test
 	public void testMultiple()
 	{
+		SimpleOperatorLibrary library = new SimpleOperatorLibrary();
 		library.addAction(new GenericEquals());
 		library.addAction(new NumberEquals());
-		assertEquals(Boolean.class,
-			library.processAbstract(Operator.EQ, NUMBER_CLASS, INTEGER_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			library.processAbstract(Operator.EQ, FormatUtilities.NUMBER_CLASS, TestUtilities.INTEGER_CLASS, null).get().getManagedClass());
 		assertEquals(Boolean.FALSE, library.evaluate(Operator.EQ, 1, 2, null));
 	}
 

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleScopeInstanceFactoryTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleScopeInstanceFactoryTest.java
@@ -17,16 +17,21 @@
  */
 package pcgen.base.formula.inst;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import junit.framework.TestCase;
 import pcgen.base.formula.base.ScopeInstance;
 import pcgen.base.formula.base.ScopeInstanceFactory;
 import pcgen.base.formula.base.VarScoped;
 
-public class SimpleScopeInstanceFactoryTest extends TestCase
+public class SimpleScopeInstanceFactoryTest
 {
 
 	private ScopeInstanceFactory factory;
@@ -34,10 +39,9 @@ public class SimpleScopeInstanceFactoryTest extends TestCase
 	private ScopeInstance scopeInst;
 	private SimpleLegalScope local;
 
-	@Override
-	protected void setUp() throws Exception
+	@BeforeEach
+	void setUp()
 	{
-		super.setUp();
 		legalScopeManager = new ScopeManagerInst();
 		factory = new SimpleScopeInstanceFactory(legalScopeManager);
 		SimpleLegalScope scope = new SimpleLegalScope("Global");
@@ -46,48 +50,34 @@ public class SimpleScopeInstanceFactoryTest extends TestCase
 		local = new SimpleLegalScope(scope, "Local");
 		legalScopeManager.registerScope(local);
 	}
+	
+	@AfterEach
+	void tearDown()
+	{
+		factory = null;
+		legalScopeManager = null;
+		scopeInst = null;
+		local = null;
+	}
 
-	@SuppressWarnings("unused")
 	@Test
 	public void testConstructor()
 	{
-		try
-		{
-			new SimpleScopeInstanceFactory(null);
-			fail("null library must be rejected");
-		}
-		catch (NullPointerException | IllegalArgumentException e)
-		{
-			//ok
-		}
+		assertThrows(NullPointerException.class, () -> new SimpleScopeInstanceFactory(null));
 	}
 
+	@Test
 	public void testGetGlobalInstance()
 	{
-		try
-		{
-			factory.getGlobalInstance("Local");
-			fail("Expected failure due to non global scope");
-		}
-		catch (IllegalArgumentException e)
-		{
-			//ok
-		}
-		try
-		{
-			factory.getGlobalInstance("Global.Local");
-			fail("Expected failure due to non global scope");
-		}
-		catch (IllegalArgumentException e)
-		{
-			//ok
-		}
+		assertThrows(IllegalArgumentException.class, () -> factory.getGlobalInstance("Local"));
+		assertThrows(IllegalArgumentException.class, () -> factory.getGlobalInstance("Global.Local"));
 		ScopeInstance globalInst = factory.getGlobalInstance("Global");
 		assertTrue(globalInst.getParentScope().isEmpty());
 		assertEquals("Global", globalInst.getLegalScope().getName());
 		assertEquals(scopeInst, globalInst);
 	}
 
+	@Test
 	public void testGet()
 	{
 		ScopeInstance gsi = factory.get("Global", Optional.empty());
@@ -113,24 +103,8 @@ public class SimpleScopeInstanceFactoryTest extends TestCase
 		assertEquals(si, gsi);
 		assertTrue(si == gsi);
 
-		try
-		{
-			factory.get("Local", Optional.of(gvs));
-			fail("Mixmatch Local and Global should fail");
-		}
-		catch (IllegalArgumentException e)
-		{
-			//ok
-		}
-		try
-		{
-			factory.get("Local", null);
-			fail("Mixmatch Local and Global should fail");
-		}
-		catch (IllegalArgumentException e)
-		{
-			//ok
-		}
+		assertThrows(IllegalArgumentException.class, () -> factory.get("Local", Optional.of(gvs)));
+		assertThrows(IllegalArgumentException.class, () -> factory.get("Local", null));
 		Scoped lvs = new Scoped("LVar", "Global.Local", gvs);
 		ScopeInstance lsi = factory.get("Global.Local", Optional.of(lvs));
 		assertTrue(local.equals(lsi.getLegalScope()));

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleScopeInstanceTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleScopeInstanceTest.java
@@ -17,130 +17,57 @@
  */
 package pcgen.base.formula.inst;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import junit.framework.TestCase;
-
-public class SimpleScopeInstanceTest extends TestCase
+public class SimpleScopeInstanceTest
 {
-
-	private static final GlobalVarScoped LOCAL_VS = new GlobalVarScoped("Local");
-	private static final GlobalVarScoped GLOBAL_VS = new GlobalVarScoped("Global");
 
 	private SimpleLegalScope scope;
 	private SimpleScopeInstance scopeInst;
 	private SimpleLegalScope local;
 	private SimpleScopeInstance localInst;
 	
-	@Override
-	protected void setUp() throws Exception
+	@BeforeEach
+	void setUp()
 	{
-		super.setUp();
 		scope = new SimpleLegalScope("Global");
-		scopeInst = new SimpleScopeInstance(Optional.empty(), scope, GLOBAL_VS);
+		scopeInst = new SimpleScopeInstance(Optional.empty(), scope, new GlobalVarScoped("Global"));
 		local = new SimpleLegalScope(scope, "Local");
-		localInst = new SimpleScopeInstance(Optional.of(scopeInst), local, LOCAL_VS);
+		localInst = new SimpleScopeInstance(Optional.of(scopeInst), local, new GlobalVarScoped("Local"));
+	}
+	
+	@AfterEach
+	void tearDown()
+	{
+		scope = null;
+		scopeInst = null;
+		local = null;
+		localInst = null;
 	}
 
-	@SuppressWarnings("unused")
 	@Test
 	public void testConstructor()
 	{
-		try
-		{
-			new SimpleScopeInstance(Optional.of(scopeInst), null, GLOBAL_VS);
-			fail("null scope must be rejected");
-		}
-		catch (NullPointerException | IllegalArgumentException e)
-		{
-			//ok
-		}
-		try
-		{
-			new SimpleScopeInstance(Optional.of(scopeInst), scope, new GlobalVarScoped("Ignored"));
-			fail("mismatch of inst, built scope must be rejected (scope parent == null)");
-		}
-		catch (IllegalArgumentException e)
-		{
-			//ok
-		}
-		try
-		{
-			new SimpleScopeInstance(Optional.of(localInst), local, new GlobalVarScoped("Ignored"));
-			fail("mismatch of inst, built scope must be rejected (neither parent null)");
-		}
-		catch (IllegalArgumentException e)
-		{
-			//ok
-		}
-		try
-		{
-			new SimpleScopeInstance(null, local, new GlobalVarScoped("Ignored"));
-			fail("non global scope without parent instance must be rejected");
-		}
-		catch (NullPointerException | IllegalArgumentException e)
-		{
-			//ok
-		}
+		assertThrows(NullPointerException.class, () -> new SimpleScopeInstance(Optional.of(scopeInst), null, new GlobalVarScoped("Global")));
+		assertThrows(IllegalArgumentException.class, () -> new SimpleScopeInstance(Optional.of(scopeInst), scope, new GlobalVarScoped("Ignored")));
+		assertThrows(IllegalArgumentException.class, () -> new SimpleScopeInstance(Optional.of(localInst), local, new GlobalVarScoped("Ignored")));
+		assertThrows(NullPointerException.class, () -> new SimpleScopeInstance(null, local, new GlobalVarScoped("Ignored")));
 		SimpleLegalScope sublocal = new SimpleLegalScope(local, "SubLocal");
-		try
-		{
-			new SimpleScopeInstance(null, local, new GlobalVarScoped("Ignored"));
-			fail("Instance should require a parent if not global");
-		}
-		catch (NullPointerException | IllegalArgumentException e)
-		{
-			//ok
-		}
-		try
-		{
-			new SimpleScopeInstance(Optional.empty(), local, new GlobalVarScoped("Ignored"));
-			fail("non global scope without parent instance must be rejected");
-		}
-		catch (NullPointerException | IllegalArgumentException e)
-		{
-			//ok
-		}
-		try
-		{
-			new SimpleScopeInstance(Optional.empty(), local, new GlobalVarScoped("Ignored"));
-			fail("Instance should require a parent if not global");
-		}
-		catch (IllegalArgumentException e)
-		{
-			//ok
-		}
+		assertThrows(NullPointerException.class, () -> new SimpleScopeInstance(null, local, new GlobalVarScoped("Ignored")));
+		assertThrows(IllegalArgumentException.class, () -> new SimpleScopeInstance(Optional.empty(), local, new GlobalVarScoped("Ignored")));
+		assertThrows(IllegalArgumentException.class, () -> new SimpleScopeInstance(Optional.empty(), local, new GlobalVarScoped("Ignored")));
 		assertEquals(scopeInst, localInst.getParentScope().get());
 		assertEquals(local, localInst.getLegalScope());
-		try
-		{
-			new SimpleScopeInstance(Optional.of(scopeInst), null, new GlobalVarScoped("Ignored"));
-			fail("LegalScope cannot be null");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
-		try
-		{
-			new SimpleScopeInstance(Optional.of(scopeInst), local, null);
-			fail("Description cannot be null");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
-		try
-		{
-			new SimpleScopeInstance(Optional.of(scopeInst), sublocal, new GlobalVarScoped("Ignored"));
-			fail("LegalScope must be a direct child of the scope of the provided instance");
-		}
-		catch (IllegalArgumentException e)
-		{
-			//ok
-		}
+		assertThrows(NullPointerException.class, () -> new SimpleScopeInstance(Optional.of(scopeInst), null, new GlobalVarScoped("Ignored")));
+		assertThrows(NullPointerException.class, () -> new SimpleScopeInstance(Optional.of(scopeInst), local, null));
+		assertThrows(IllegalArgumentException.class, () -> new SimpleScopeInstance(Optional.of(scopeInst), sublocal, new GlobalVarScoped("Ignored")));
 	}
 
 	@Test

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleVariableStoreTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleVariableStoreTest.java
@@ -17,53 +17,55 @@
  */
 package pcgen.base.formula.inst;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import pcgen.base.format.NumberManager;
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.ScopeInstance;
 import pcgen.base.formula.base.ScopeInstanceFactory;
 import pcgen.base.formula.base.VariableID;
 
-public class SimpleVariableStoreTest extends TestCase
+public class SimpleVariableStoreTest
 {
 
 	private ScopeManagerInst legalScopeManager;
 	private ScopeInstanceFactory instanceFactory;
 		
-	@Override
-	protected void setUp() throws Exception
+	@BeforeEach
+	void setUp()
 	{
-		super.setUp();
 		legalScopeManager = new ScopeManagerInst();
 		legalScopeManager.registerScope(new SimpleLegalScope("Global"));
 		instanceFactory = new SimpleScopeInstanceFactory(legalScopeManager);
 	}
+	
+	@AfterEach
+	void tearDown()
+	{
+		legalScopeManager = null;
+		instanceFactory = null;
+	}
 
+	@Test
 	public void testNulls()
 	{
 		SimpleVariableStore varStore = new SimpleVariableStore();
 		NumberManager numberManager = new NumberManager();
 		ScopeInstance globalInst = instanceFactory.getGlobalInstance("Global");
 		VariableID<Number> vid = new VariableID<>(globalInst, numberManager, "test");
-		try
-		{
-			varStore.put(null, Integer.valueOf(4));
-			fail();
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//yep
-		}
-		try
-		{
-			varStore.put(vid, null);
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//yep
-		}
+		assertThrows(NullPointerException.class, () -> varStore.put(null, Integer.valueOf(4)));
+		assertThrows(NullPointerException.class, () -> varStore.put(vid, null));
 	}
 
+	@Test
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	public void testGenericsViolation()
 	{
@@ -71,18 +73,11 @@ public class SimpleVariableStoreTest extends TestCase
 		NumberManager numberManager = new NumberManager();
 		ScopeInstance globalInst = instanceFactory.getGlobalInstance("Global");
 		VariableID vid = new VariableID<>(globalInst, numberManager, "test");
-		try
-		{
-			//Intentionally break generics
-			varStore.put(vid, "NotANumber!");
-			fail();
-		}
-		catch (IllegalArgumentException e)
-		{
-			//yep
-		}
+		//Intentionally break generics
+		assertThrows(IllegalArgumentException.class, () -> varStore.put(vid, "NotANumber!"));
 	}
 
+	@Test
 	public void testGlobal()
 	{
 		SimpleVariableStore varStore = new SimpleVariableStore();
@@ -98,6 +93,7 @@ public class SimpleVariableStoreTest extends TestCase
 		assertEquals(Integer.valueOf(4), varStore.get(vid));
 	}
 
+	@Test
 	public void testIndependence()
 	{
 		SimpleVariableStore varStore = new SimpleVariableStore();

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/VariableManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/VariableManagerTest.java
@@ -17,14 +17,18 @@
  */
 package pcgen.base.formula.inst;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import junit.framework.TestCase;
-import pcgen.base.format.BooleanManager;
-import pcgen.base.format.NumberManager;
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.LegalScope;
 import pcgen.base.formula.base.ScopeInstance;
@@ -37,20 +41,17 @@ import pcgen.base.solver.SupplierValueStore;
 import pcgen.base.testsupport.SimpleVarScoped;
 import pcgen.base.util.Indirect;
 
-public class VariableManagerTest extends TestCase
+public class VariableManagerTest
 {
 
-	private NumberManager numberManager = FormatUtilities.NUMBER_MANAGER;
-	private BooleanManager booleanManager = FormatUtilities.BOOLEAN_MANAGER;
 	private ScopeInstanceFactory instanceFactory;
 	private ScopeManagerInst legalScopeManager;
 	private VariableLibrary variableLibrary;
 	private SupplierValueStore valueStore;
 
-	@Override
-	protected void setUp() throws Exception
+	@BeforeEach
+	void setUp()
 	{
-		super.setUp();
 		valueStore = new SupplierValueStore();
 		legalScopeManager = new ScopeManagerInst();
 		instanceFactory = new SimpleScopeInstanceFactory(legalScopeManager);
@@ -59,98 +60,34 @@ public class VariableManagerTest extends TestCase
 		valueStore.addValueFor(FormatUtilities.BOOLEAN_MANAGER, () -> false);
 		variableLibrary = new VariableManager(legalScopeManager, valueStore);
 	}
+	
+	@AfterEach
+	void tearDown()
+	{
+		instanceFactory = null;
+		legalScopeManager = null;
+		variableLibrary = null;
+		valueStore = null;
+	}
 
-	@SuppressWarnings("unused")
 	@Test
 	public void testNullConstructor()
 	{
-		try
-		{
-			new VariableManager(null, valueStore);
-			fail("null must be rejected in constructor");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
-		try
-		{
-			new VariableManager(legalScopeManager, null);
-			fail("null must be rejected in constructor");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
-		try
-		{
-			new VariableManager(null, null);
-			fail("null must be rejected in constructor");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
+		assertThrows(NullPointerException.class, () -> new VariableManager(null, valueStore));
+		assertThrows(NullPointerException.class, () -> new VariableManager(legalScopeManager, null));
+		assertThrows(NullPointerException.class, () -> new VariableManager(null, null));
 	}
 
 	@Test
 	public void testAssertVariableFail()
 	{
 		LegalScope globalScope = new SimpleLegalScope("Global");
-		try
-		{
-			variableLibrary.assertLegalVariableID(null, globalScope, numberManager);
-			fail("null var must be rejected");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
-		try
-		{
-			variableLibrary.assertLegalVariableID("", globalScope, numberManager);
-			fail("empty var must be rejected");
-		}
-		catch (IllegalArgumentException e)
-		{
-			//ok
-		}
-		try
-		{
-			variableLibrary.assertLegalVariableID(" Walk", globalScope, numberManager);
-			fail("padded var must be rejected");
-		}
-		catch (IllegalArgumentException e)
-		{
-			//ok
-		}
-		try
-		{
-			variableLibrary.assertLegalVariableID("Walk ", globalScope, numberManager);
-			fail("padded var must be rejected");
-		}
-		catch (IllegalArgumentException e)
-		{
-			//ok
-		}
-		try
-		{
-			variableLibrary.assertLegalVariableID("Walk", globalScope, null);
-			fail("null FormatManager must be rejected");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
-		try
-		{
-			variableLibrary.assertLegalVariableID("Walk", null, numberManager);
-			fail("null scope must be rejected");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
+		assertThrows(NullPointerException.class, () -> variableLibrary.assertLegalVariableID(null, globalScope, FormatUtilities.NUMBER_MANAGER));
+		assertThrows(IllegalArgumentException.class, () -> variableLibrary.assertLegalVariableID("", globalScope, FormatUtilities.NUMBER_MANAGER));
+		assertThrows(IllegalArgumentException.class, () -> variableLibrary.assertLegalVariableID(" Walk", globalScope, FormatUtilities.NUMBER_MANAGER));
+		assertThrows(IllegalArgumentException.class, () -> variableLibrary.assertLegalVariableID("Walk ", globalScope, FormatUtilities.NUMBER_MANAGER));
+		assertThrows(NullPointerException.class, () -> variableLibrary.assertLegalVariableID("Walk", globalScope, null));
+		assertThrows(NullPointerException.class, () -> variableLibrary.assertLegalVariableID("Walk", null, FormatUtilities.NUMBER_MANAGER));
 		//Just to check
 		try
 		{
@@ -158,7 +95,7 @@ public class VariableManagerTest extends TestCase
 		}
 		catch (IllegalArgumentException | NullPointerException e)
 		{
-			//ok
+			//ok too
 		}
 		assertFalse(variableLibrary.isLegalVariableID(globalScope, ""));
 		assertFalse(variableLibrary.isLegalVariableID(globalScope, " Walk"));
@@ -176,83 +113,27 @@ public class VariableManagerTest extends TestCase
 		legalScopeManager.registerScope(spScope);
 		legalScopeManager.registerScope(eqScope);
 		legalScopeManager.registerScope(eqPartScope);
-		variableLibrary.assertLegalVariableID("Walk", globalScope, numberManager);
+		variableLibrary.assertLegalVariableID("Walk", globalScope, FormatUtilities.NUMBER_MANAGER);
 		//Dupe is safe
-		variableLibrary.assertLegalVariableID("Walk", globalScope, numberManager);
-		try
-		{
-			variableLibrary.assertLegalVariableID("Walk", globalScope, booleanManager);
-			fail("different format should fail");
-		}
-		catch (LegalVariableException e)
-		{
-			//expected
-		}
-		try
-		{
-			variableLibrary.assertLegalVariableID("Walk", eqScope, numberManager);
-			fail("child scope of existing should fail");
-		}
-		catch (LegalVariableException e)
-		{
-			//expected
-		}
+		variableLibrary.assertLegalVariableID("Walk", globalScope, FormatUtilities.NUMBER_MANAGER);
+		assertThrows(LegalVariableException.class, () -> variableLibrary.assertLegalVariableID("Walk", globalScope, FormatUtilities.BOOLEAN_MANAGER));
+		assertThrows(LegalVariableException.class, () -> variableLibrary.assertLegalVariableID("Walk", eqScope, FormatUtilities.NUMBER_MANAGER));
 		//Check child recursive
-		try
-		{
-			variableLibrary.assertLegalVariableID("Walk", eqPartScope, numberManager);
-			fail("child scope (recursive) of existing should fail");
-		}
-		catch (LegalVariableException e)
-		{
-			//expected
-		}
-		variableLibrary.assertLegalVariableID("Float", eqScope, numberManager);
-		try
-		{
-			variableLibrary.assertLegalVariableID("Float", eqPartScope, numberManager);
-			fail("child scope of existing should fail");
-		}
-		catch (LegalVariableException e)
-		{
-			//expected
-		}
-		try
-		{
-			variableLibrary.assertLegalVariableID("Float", globalScope, numberManager);
-			fail("parent scope of existing should fail");
-		}
-		catch (LegalVariableException e)
-		{
-			//expected
-		}
+		assertThrows(LegalVariableException.class, () -> variableLibrary.assertLegalVariableID("Walk", eqPartScope, FormatUtilities.NUMBER_MANAGER));
+		variableLibrary.assertLegalVariableID("Float", eqScope, FormatUtilities.NUMBER_MANAGER);
+		assertThrows(LegalVariableException.class, () -> variableLibrary.assertLegalVariableID("Float", eqPartScope, FormatUtilities.NUMBER_MANAGER));
+		assertThrows(LegalVariableException.class, () -> variableLibrary.assertLegalVariableID("Float", globalScope, FormatUtilities.NUMBER_MANAGER));
 		//Allow peer
-		variableLibrary.assertLegalVariableID("Float", spScope, numberManager);
-		variableLibrary.assertLegalVariableID("Hover", eqPartScope, numberManager);
-		try
-		{
-			variableLibrary.assertLegalVariableID("Hover", eqScope, numberManager);
-			fail("parent scope of existing should fail");
-		}
-		catch (LegalVariableException e)
-		{
-			//expected
-		}
-		try
-		{
-			variableLibrary.assertLegalVariableID("Hover", globalScope, numberManager);
-			fail("parent scope (recursive) of existing should fail");
-		}
-		catch (LegalVariableException e)
-		{
-			//expected
-		}
-		variableLibrary.assertLegalVariableID("Drive", spScope, numberManager);
+		variableLibrary.assertLegalVariableID("Float", spScope, FormatUtilities.NUMBER_MANAGER);
+		variableLibrary.assertLegalVariableID("Hover", eqPartScope, FormatUtilities.NUMBER_MANAGER);
+		assertThrows(LegalVariableException.class, () -> variableLibrary.assertLegalVariableID("Hover", eqScope, FormatUtilities.NUMBER_MANAGER));
+		assertThrows(LegalVariableException.class, () -> variableLibrary.assertLegalVariableID("Hover", globalScope, FormatUtilities.NUMBER_MANAGER));
+		variableLibrary.assertLegalVariableID("Drive", spScope, FormatUtilities.NUMBER_MANAGER);
 		//Check peer child
-		variableLibrary.assertLegalVariableID("Drive", eqPartScope, numberManager);
-		variableLibrary.assertLegalVariableID("Fly", spScope, numberManager);
+		variableLibrary.assertLegalVariableID("Drive", eqPartScope, FormatUtilities.NUMBER_MANAGER);
+		variableLibrary.assertLegalVariableID("Fly", spScope, FormatUtilities.NUMBER_MANAGER);
 		//Check peer with children
-		variableLibrary.assertLegalVariableID("Fly", eqScope, numberManager);
+		variableLibrary.assertLegalVariableID("Fly", eqScope, FormatUtilities.NUMBER_MANAGER);
 	}
 
 	@Test
@@ -260,16 +141,8 @@ public class VariableManagerTest extends TestCase
 	{
 		LegalScope globalScope = new SimpleLegalScope("Global");
 		legalScopeManager.registerScope(globalScope);
-		variableLibrary.assertLegalVariableID("Walk", globalScope, numberManager);
-		try
-		{
-			variableLibrary.isLegalVariableID(null, "Walk");
-			fail("null FormatManager must be rejected");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
+		variableLibrary.assertLegalVariableID("Walk", globalScope, FormatUtilities.NUMBER_MANAGER);
+		assertThrows(NullPointerException.class, () -> variableLibrary.isLegalVariableID(null, "Walk"));
 		try
 		{
 			assertFalse(variableLibrary.isLegalVariableID(globalScope, null));
@@ -291,7 +164,7 @@ public class VariableManagerTest extends TestCase
 		legalScopeManager.registerScope(spScope);
 		legalScopeManager.registerScope(eqScope);
 		legalScopeManager.registerScope(eqPartScope);
-		variableLibrary.assertLegalVariableID("Walk", globalScope, numberManager);
+		variableLibrary.assertLegalVariableID("Walk", globalScope, FormatUtilities.NUMBER_MANAGER);
 		assertTrue(variableLibrary.isLegalVariableID(globalScope, "Walk"));
 		assertFalse(variableLibrary.isLegalVariableID(globalScope, "Run"));
 		//Works for child
@@ -299,7 +172,7 @@ public class VariableManagerTest extends TestCase
 		//Works for child recursively
 		assertTrue(variableLibrary.isLegalVariableID(eqPartScope, "Walk"));
 
-		variableLibrary.assertLegalVariableID("Float", eqScope, numberManager);
+		variableLibrary.assertLegalVariableID("Float", eqScope, FormatUtilities.NUMBER_MANAGER);
 		assertTrue(variableLibrary.isLegalVariableID(eqScope, "Float"));
 		//Works for child 
 		assertTrue(variableLibrary.isLegalVariableID(eqPartScope, "Float"));
@@ -308,7 +181,7 @@ public class VariableManagerTest extends TestCase
 		//and not peer
 		assertFalse(variableLibrary.isLegalVariableID(spScope, "Float"));
 
-		variableLibrary.assertLegalVariableID("Hover", eqPartScope, numberManager);
+		variableLibrary.assertLegalVariableID("Hover", eqPartScope, FormatUtilities.NUMBER_MANAGER);
 		assertTrue(variableLibrary.isLegalVariableID(eqPartScope, "Hover"));
 		//but not parent
 		assertFalse(variableLibrary.isLegalVariableID(eqScope, "Hover"));
@@ -332,80 +205,15 @@ public class VariableManagerTest extends TestCase
 		eq.scopeName = "Global.Equipment";
 		eq.name = "Sword";
 		ScopeInstance eqInst = instanceFactory.get("Global.Equipment", Optional.of(eq));
-		try
-		{
-			variableLibrary.getVariableID(null, "Walk");
-			fail("null scope must be rejected");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
-		try
-		{
-			variableLibrary.getVariableID(globalInst, null);
-			fail("null name must be rejected");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
-		try
-		{
-			variableLibrary.getVariableID(globalInst, "");
-			fail("empty name must be rejected");
-		}
-		catch (IllegalArgumentException e)
-		{
-			//ok
-		}
-		try
-		{
-			variableLibrary.getVariableID(globalInst, " Walk");
-			fail("padded name must be rejected");
-		}
-		catch (IllegalArgumentException e)
-		{
-			//ok
-		}
-		try
-		{
-			variableLibrary.getVariableID(globalInst, "Walk ");
-			fail("padded name must be rejected");
-		}
-		catch (IllegalArgumentException e)
-		{
-			//ok
-		}
-		try
-		{
-			variableLibrary.getVariableID(globalInst, "Walk");
-			fail("undefined name must be rejected");
-		}
-		catch (NoSuchElementException | IllegalArgumentException | NullPointerException e)
-		{
-			//undefined, ok
-		}
-		try
-		{
-			variableLibrary.getVariableID(eqInst, "Walk");
-			fail("undefined name must be rejected");
-		}
-		catch (NoSuchElementException | IllegalArgumentException | NullPointerException e)
-		{
-			//undefined, ok
-		}
-		variableLibrary.assertLegalVariableID("Float", spScope, numberManager);
-		try
-		{
-			variableLibrary.getVariableID(eqInst, "Float");
-			fail("undefined name (unrelated scope) must be rejected");
-		}
-		catch (NoSuchElementException | IllegalArgumentException | NullPointerException e)
-		{
-			//undefined, ok
-		}
-
+		assertThrows(NullPointerException.class, () -> variableLibrary.getVariableID(null, "Walk"));
+		assertThrows(NullPointerException.class, () -> variableLibrary.getVariableID(globalInst, null));
+		assertThrows(IllegalArgumentException.class, () -> variableLibrary.getVariableID(globalInst, ""));
+		assertThrows(IllegalArgumentException.class, () -> variableLibrary.getVariableID(globalInst, " Walk"));
+		assertThrows(IllegalArgumentException.class, () -> variableLibrary.getVariableID(globalInst, "Walk "));
+		assertThrows(NoSuchElementException.class, () -> variableLibrary.getVariableID(globalInst, "Walk"));
+		assertThrows(NoSuchElementException.class, () -> variableLibrary.getVariableID(eqInst, "Walk"));
+		variableLibrary.assertLegalVariableID("Float", spScope, FormatUtilities.NUMBER_MANAGER);
+		assertThrows(NoSuchElementException.class, () -> variableLibrary.getVariableID(eqInst, "Float"));
 	}
 
 	@Test
@@ -427,9 +235,9 @@ public class VariableManagerTest extends TestCase
 		eqpart.name = "Mod";
 		eqpart.parent = eq;
 		ScopeInstance eqPartInst = instanceFactory.get("Global.Equipment.Part", Optional.of(eqpart));
-		variableLibrary.assertLegalVariableID("Walk", globalScope, numberManager);
-		variableLibrary.assertLegalVariableID("Float", eqScope, numberManager);
-		variableLibrary.assertLegalVariableID("Hover", eqPartScope, numberManager);
+		variableLibrary.assertLegalVariableID("Walk", globalScope, FormatUtilities.NUMBER_MANAGER);
+		variableLibrary.assertLegalVariableID("Float", eqScope, FormatUtilities.NUMBER_MANAGER);
+		variableLibrary.assertLegalVariableID("Hover", eqPartScope, FormatUtilities.NUMBER_MANAGER);
 		VariableID<?> vid = variableLibrary.getVariableID(globalInst, "Walk");
 		assertEquals("Walk", vid.getName());
 		assertEquals(globalInst, vid.getScope());
@@ -470,17 +278,9 @@ public class VariableManagerTest extends TestCase
 		LegalScope eqScope = new SimpleLegalScope(globalScope, "Equipment");
 		legalScopeManager.registerScope(globalScope);
 		legalScopeManager.registerScope(eqScope);
-		variableLibrary.assertLegalVariableID("Walk", globalScope, numberManager);
-		variableLibrary.assertLegalVariableID("Float", eqScope, numberManager);
-		try
-		{
-			variableLibrary.getVariableFormat(null, "Walk");
-			fail();
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
+		variableLibrary.assertLegalVariableID("Walk", globalScope, FormatUtilities.NUMBER_MANAGER);
+		variableLibrary.assertLegalVariableID("Float", eqScope, FormatUtilities.NUMBER_MANAGER);
+		assertThrows(NullPointerException.class, () -> variableLibrary.getVariableFormat(null, "Walk"));
 		try
 		{
 			Object o = variableLibrary.getVariableFormat(globalScope, null);
@@ -490,13 +290,13 @@ public class VariableManagerTest extends TestCase
 		{
 			//ok too
 		}
-		assertTrue(numberManager
+		assertTrue(FormatUtilities.NUMBER_MANAGER
 			.equals(variableLibrary.getVariableFormat(globalScope, "Walk")));
 		assertTrue(
-			numberManager.equals(variableLibrary.getVariableFormat(eqScope, "Float")));
+			FormatUtilities.NUMBER_MANAGER.equals(variableLibrary.getVariableFormat(eqScope, "Float")));
 		//fail at depth
 		assertTrue(
-			numberManager.equals(variableLibrary.getVariableFormat(eqScope, "Walk")));
+			FormatUtilities.NUMBER_MANAGER.equals(variableLibrary.getVariableFormat(eqScope, "Walk")));
 		//work indirect
 		assertTrue(variableLibrary.getVariableFormat(globalScope, "Float") == null);
 	}
@@ -520,17 +320,17 @@ public class VariableManagerTest extends TestCase
 		ab.name = "Dodge";
 		ScopeInstance abInst = instanceFactory.get("Global.Ability", Optional.of(ab));
 
-		variableLibrary.assertLegalVariableID("Walk", eqScope, numberManager);
+		variableLibrary.assertLegalVariableID("Walk", eqScope, FormatUtilities.NUMBER_MANAGER);
 		VariableID<?> vidm = variableLibrary.getVariableID(eqInst, "Walk");
 		assertEquals("Walk", vidm.getName());
 		assertEquals(eqInst, vidm.getScope());
 		assertEquals(Number.class, vidm.getVariableFormat());
 
-		variableLibrary.assertLegalVariableID("Walk", abScope, booleanManager);
+		variableLibrary.assertLegalVariableID("Walk", abScope, FormatUtilities.BOOLEAN_MANAGER);
 		VariableID<?> vidf = variableLibrary.getVariableID(abInst, "Walk");
 		assertEquals("Walk", vidf.getName());
 		assertEquals(abInst, vidf.getScope());
-		assertEquals(Boolean.class, vidf.getVariableFormat());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS, vidf.getVariableFormat());
 
 		assertFalse(vidm.equals(vidf));
 		assertFalse(vidf.equals(vidm));

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/library/ArgFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/library/ArgFunctionTest.java
@@ -17,9 +17,14 @@
  */
 package pcgen.base.formula.library;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.analysis.ArgumentDependencyManager;
@@ -41,12 +46,22 @@ public class ArgFunctionTest extends AbstractFormulaTestCase
 	private DependencyManager depManager;
 	private DependencyVisitor varCapture;
 
+	@BeforeEach
 	@Override
-	protected void setUp() throws Exception
+	protected void setUp()
 	{
 		super.setUp();
 		resetManager();
 		varCapture = new DependencyVisitor();
+	}
+
+	@AfterEach
+	@Override
+	protected void tearDown()
+	{
+		varCapture = null;
+		depManager = null;
+		argManager = null;
 	}
 
 	private Node[] getNodes()

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/library/GenericFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/library/GenericFunctionTest.java
@@ -17,9 +17,14 @@
  */
 package pcgen.base.formula.library;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.analysis.ArgumentDependencyManager;
@@ -39,11 +44,22 @@ public class GenericFunctionTest extends AbstractFormulaTestCase
 	private DependencyManager depManager;
 	private DependencyVisitor varCapture;
 
+	@BeforeEach
 	@Override
-	protected void setUp() throws Exception
+	protected void setUp()
 	{
 		super.setUp();
 		resetManager();
+	}
+
+	@AfterEach
+	@Override
+	protected void tearDown()
+	{
+		super.tearDown();
+		argManager = null;
+		depManager = null;
+		varCapture = null;
 	}
 
 	private void resetManager()

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/operator/array/ArrayAddTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/operator/array/ArrayAddTest.java
@@ -15,44 +15,33 @@
  */
 package pcgen.base.formula.operator.array;
 
-import java.lang.reflect.Array;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Optional;
 
-import junit.framework.TestCase;
-import pcgen.base.format.ArrayFormatManager;
-import pcgen.base.format.BooleanManager;
-import pcgen.base.format.NumberManager;
-import pcgen.base.util.FormatManager;
+import org.junit.jupiter.api.Test;
 
-public class ArrayAddTest extends TestCase
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.testsupport.TestUtilities;
+
+public class ArrayAddTest
 {
-
-	private static final Class<Number> NUMBER_CLASS = Number.class;
-	private static final Class<Boolean> BOOLEAN_CLASS = Boolean.class;
-	private static final Class<Integer> INTEGER_CLASS = Integer.class;
-	private static final Class<Object[]> OBJECT_ARRAY_CLASS =
-			(Class<Object[]>) Array.newInstance(Object.class, 0).getClass();
-	private static final Class<Number[]> NUMBER_ARRAY_CLASS =
-			(Class<Number[]>) Array.newInstance(NUMBER_CLASS, 0).getClass();
-	private static final Class<Boolean[]> BOOLEAN_ARRAY_CLASS =
-			(Class<Boolean[]>) Array.newInstance(BOOLEAN_CLASS, 0).getClass();
-	private static final Class<Integer[]> INTEGER_ARRAY_CLASS =
-			(Class<Integer[]>) Array.newInstance(INTEGER_CLASS, 0).getClass();
-	FormatManager<Number[]> numberArrayManager =
-			new ArrayFormatManager<>(new NumberManager(), ',', '|');
-	FormatManager<Boolean[]> booleanArrayManager =
-			new ArrayFormatManager<>(new BooleanManager(), ',', '|');
-
-	private final ArrayAdd op = new ArrayAdd();
-
+	@Test
 	public void testOperator()
 	{
+		ArrayAdd op = new ArrayAdd();
 		assertNotNull(op.getOperator());
 		assertTrue(op.getOperator().getSymbol().equals("+"));
 	}
 
+	@Test
 	public void testAbstractEvaluateNulls()
 	{
+		ArrayAdd op = new ArrayAdd();
 		try
 		{
 			assertNull(op.abstractEvaluate(null, null, null));
@@ -63,7 +52,7 @@ public class ArrayAddTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(NUMBER_ARRAY_CLASS, null, null));
+			assertNull(op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, null, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -71,7 +60,7 @@ public class ArrayAddTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(null, NUMBER_ARRAY_CLASS, null));
+			assertNull(op.abstractEvaluate(null, TestUtilities.NUMBER_ARRAY_CLASS, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -79,7 +68,7 @@ public class ArrayAddTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(NUMBER_ARRAY_CLASS, NUMBER_ARRAY_CLASS, null));
+			assertNull(op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, TestUtilities.NUMBER_ARRAY_CLASS, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -87,39 +76,43 @@ public class ArrayAddTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testAbstractEvaluateMismatch()
 	{
-		assertTrue(op.abstractEvaluate(NUMBER_ARRAY_CLASS, BOOLEAN_ARRAY_CLASS,
+		ArrayAdd op = new ArrayAdd();
+		assertTrue(op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, TestUtilities.BOOLEAN_ARRAY_CLASS,
 			Optional.empty()).isEmpty());
-		assertTrue(op.abstractEvaluate(BOOLEAN_ARRAY_CLASS, INTEGER_ARRAY_CLASS,
-			Optional.of(booleanArrayManager)).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_ARRAY_CLASS, NUMBER_ARRAY_CLASS,
-			Optional.of(booleanArrayManager)).isEmpty());
-		assertTrue(op.abstractEvaluate(BOOLEAN_ARRAY_CLASS, INTEGER_CLASS,
-			Optional.of(booleanArrayManager)).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_ARRAY_CLASS, NUMBER_CLASS,
-			Optional.of(booleanArrayManager)).isEmpty());
+		assertTrue(op.abstractEvaluate(TestUtilities.BOOLEAN_ARRAY_CLASS, TestUtilities.INTEGER_ARRAY_CLASS,
+			Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).isEmpty());
+		assertTrue(op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, TestUtilities.NUMBER_ARRAY_CLASS,
+			Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).isEmpty());
+		assertTrue(op.abstractEvaluate(TestUtilities.BOOLEAN_ARRAY_CLASS, TestUtilities.INTEGER_CLASS,
+			Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).isEmpty());
+		assertTrue(op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, FormatUtilities.NUMBER_CLASS,
+			Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).isEmpty());
 	}
 
+	@Test
 	public void testAbstractEvaluateLegal()
 	{
-		assertEquals(NUMBER_ARRAY_CLASS, op.abstractEvaluate(NUMBER_ARRAY_CLASS,
-			NUMBER_ARRAY_CLASS, Optional.of(numberArrayManager)).get().getManagedClass());
-		assertEquals(BOOLEAN_ARRAY_CLASS, op.abstractEvaluate(BOOLEAN_ARRAY_CLASS,
-			BOOLEAN_ARRAY_CLASS, Optional.of(booleanArrayManager)).get().getManagedClass());
-		assertEquals(NUMBER_ARRAY_CLASS, op.abstractEvaluate(NUMBER_ARRAY_CLASS,
-			NUMBER_CLASS, Optional.of(numberArrayManager)).get().getManagedClass());
-		assertEquals(BOOLEAN_ARRAY_CLASS, op.abstractEvaluate(BOOLEAN_ARRAY_CLASS,
-			BOOLEAN_CLASS, Optional.of(booleanArrayManager)).get().getManagedClass());
-		assertEquals(NUMBER_ARRAY_CLASS, op.abstractEvaluate(NUMBER_CLASS,
-			NUMBER_ARRAY_CLASS, Optional.of(numberArrayManager)).get().getManagedClass());
-		assertEquals(BOOLEAN_ARRAY_CLASS, op.abstractEvaluate(BOOLEAN_CLASS,
-			BOOLEAN_ARRAY_CLASS, Optional.of(booleanArrayManager)).get().getManagedClass());
-		assertEquals(NUMBER_ARRAY_CLASS, op
-			.abstractEvaluate(NUMBER_CLASS, NUMBER_CLASS, Optional.of(numberArrayManager))
+		ArrayAdd op = new ArrayAdd();
+		assertEquals(TestUtilities.NUMBER_ARRAY_CLASS, op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS,
+			TestUtilities.NUMBER_ARRAY_CLASS, Optional.of(TestUtilities.NUMBER_ARRAY_MANAGER)).get().getManagedClass());
+		assertEquals(TestUtilities.BOOLEAN_ARRAY_CLASS, op.abstractEvaluate(TestUtilities.BOOLEAN_ARRAY_CLASS,
+			TestUtilities.BOOLEAN_ARRAY_CLASS, Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).get().getManagedClass());
+		assertEquals(TestUtilities.NUMBER_ARRAY_CLASS, op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS,
+			FormatUtilities.NUMBER_CLASS, Optional.of(TestUtilities.NUMBER_ARRAY_MANAGER)).get().getManagedClass());
+		assertEquals(TestUtilities.BOOLEAN_ARRAY_CLASS, op.abstractEvaluate(TestUtilities.BOOLEAN_ARRAY_CLASS,
+			FormatUtilities.BOOLEAN_CLASS, Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).get().getManagedClass());
+		assertEquals(TestUtilities.NUMBER_ARRAY_CLASS, op.abstractEvaluate(FormatUtilities.NUMBER_CLASS,
+			TestUtilities.NUMBER_ARRAY_CLASS, Optional.of(TestUtilities.NUMBER_ARRAY_MANAGER)).get().getManagedClass());
+		assertEquals(TestUtilities.BOOLEAN_ARRAY_CLASS, op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS,
+			TestUtilities.BOOLEAN_ARRAY_CLASS, Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).get().getManagedClass());
+		assertEquals(TestUtilities.NUMBER_ARRAY_CLASS, op
+			.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.NUMBER_CLASS, Optional.of(TestUtilities.NUMBER_ARRAY_MANAGER))
 			.get().getManagedClass());
-		assertEquals(BOOLEAN_ARRAY_CLASS, op.abstractEvaluate(BOOLEAN_CLASS,
-			BOOLEAN_CLASS, Optional.of(booleanArrayManager)).get().getManagedClass());
+		assertEquals(TestUtilities.BOOLEAN_ARRAY_CLASS, op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS,
+			FormatUtilities.BOOLEAN_CLASS, Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).get().getManagedClass());
 		//TODO Interesting that these REQUIRE a format assertion... why?
 //		assertEquals(NUMBER_ARRAY_CLASS,
 //			op.abstractEvaluate(NUMBER_ARRAY_CLASS, NUMBER_ARRAY_CLASS, Optional.empty())
@@ -129,44 +122,14 @@ public class ArrayAddTest extends TestCase
 //			.getManagedClass());
 	}
 
+	@Test
 	public void testEvaluateFailNull()
 	{
-		try
-		{
-			assertNull(op.evaluate(null, null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(Boolean.TRUE, null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(new Boolean[0], null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(null, Boolean.FALSE));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
+		ArrayAdd op = new ArrayAdd();
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(Boolean.TRUE, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(new Boolean[0], null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, Boolean.FALSE));
 	}
 
 	//TODO How to catch these? :/
@@ -192,11 +155,13 @@ public class ArrayAddTest extends TestCase
 //		}
 //	}
 
+	@Test
 	public void testEvaluateLegalArrayObject()
 	{
+		ArrayAdd op = new ArrayAdd();
 		Number[] iArray = new Number[]{1, 2};
 		Object result = op.evaluate(iArray, 4.5);
-		assertTrue(result.getClass().equals(OBJECT_ARRAY_CLASS));
+		assertTrue(result.getClass().equals(TestUtilities.OBJECT_ARRAY_CLASS));
 		Object[] resultArray = (Object[]) result;
 		assertEquals(3, resultArray.length);
 		assertEquals(1, resultArray[0]);
@@ -204,11 +169,13 @@ public class ArrayAddTest extends TestCase
 		assertEquals(4.5, resultArray[2]);
 	}
 
+	@Test
 	public void testEvaluateLegalArrayArray()
 	{
+		ArrayAdd op = new ArrayAdd();
 		Number[] iArray = new Number[]{1, 2};
 		Object result = op.evaluate(iArray, new Number[]{4.5, -6});
-		assertTrue(result.getClass().equals(OBJECT_ARRAY_CLASS));
+		assertTrue(result.getClass().equals(TestUtilities.OBJECT_ARRAY_CLASS));
 		Object[] resultArray = (Object[]) result;
 		assertEquals(4, resultArray.length);
 		assertEquals(1, resultArray[0]);
@@ -217,10 +184,12 @@ public class ArrayAddTest extends TestCase
 		assertEquals(-6, resultArray[3]);
 	}
 
+	@Test
 	public void testEvaluateLegalObjectArray()
 	{
+		ArrayAdd op = new ArrayAdd();
 		Object result = op.evaluate(1, new Number[]{4.5, -6});
-		assertTrue(result.getClass().equals(OBJECT_ARRAY_CLASS));
+		assertTrue(result.getClass().equals(TestUtilities.OBJECT_ARRAY_CLASS));
 		Object[] resultArray = (Object[]) result;
 		assertEquals(3, resultArray.length);
 		assertEquals(1, resultArray[0]);
@@ -228,10 +197,12 @@ public class ArrayAddTest extends TestCase
 		assertEquals(-6, resultArray[2]);
 	}
 
+	@Test
 	public void testEvaluateLegalObjectObject()
 	{
+		ArrayAdd op = new ArrayAdd();
 		Object result = op.evaluate(1, -6);
-		assertTrue(result.getClass().equals(OBJECT_ARRAY_CLASS));
+		assertTrue(result.getClass().equals(TestUtilities.OBJECT_ARRAY_CLASS));
 		Object[] resultArray = (Object[]) result;
 		assertEquals(2, resultArray.length);
 		assertEquals(1, resultArray[0]);

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/operator/array/ArrayEqualsTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/operator/array/ArrayEqualsTest.java
@@ -15,43 +15,34 @@
  */
 package pcgen.base.formula.operator.array;
 
-import java.lang.reflect.Array;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Optional;
 
-import junit.framework.TestCase;
-import pcgen.base.format.ArrayFormatManager;
-import pcgen.base.format.BooleanManager;
-import pcgen.base.format.NumberManager;
-import pcgen.base.util.FormatManager;
+import org.junit.jupiter.api.Test;
 
-public class ArrayEqualsTest extends TestCase
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.testsupport.TestUtilities;
+
+public class ArrayEqualsTest
 {
-
-	private static final Class<Number> NUMBER_CLASS = Number.class;
-	private static final Class<Boolean> BOOLEAN_CLASS = Boolean.class;
-	private static final Class<Integer> INTEGER_CLASS = Integer.class;
-	private static final Class<Number[]> NUMBER_ARRAY_CLASS =
-			(Class<Number[]>) Array.newInstance(NUMBER_CLASS, 0).getClass();
-	private static final Class<Boolean[]> BOOLEAN_ARRAY_CLASS =
-			(Class<Boolean[]>) Array.newInstance(BOOLEAN_CLASS, 0).getClass();
-	private static final Class<Integer[]> INTEGER_ARRAY_CLASS =
-			(Class<Integer[]>) Array.newInstance(INTEGER_CLASS, 0).getClass();
-	private final BooleanManager booleanManager = new BooleanManager();
-	private final FormatManager<Number[]> numberArrayManager =
-			new ArrayFormatManager<>(new NumberManager(), ',', '|');
-	private final FormatManager<Boolean[]> booleanArrayManager =
-			new ArrayFormatManager<>(booleanManager, ',', '|');
-
-	private final ArrayEquals op = new ArrayEquals();
-
+	@Test
 	public void testOperator()
 	{
+		ArrayEquals op = new ArrayEquals();
 		assertNotNull(op.getOperator());
 		assertTrue(op.getOperator().getSymbol().equals("=="));
 	}
 
+	@Test
 	public void testAbstractEvaluateNulls()
 	{
+		ArrayEquals op = new ArrayEquals();
 		try
 		{
 			assertNull(op.abstractEvaluate(null, null, null));
@@ -62,7 +53,7 @@ public class ArrayEqualsTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(NUMBER_ARRAY_CLASS, null, null));
+			assertNull(op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, null, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -70,7 +61,7 @@ public class ArrayEqualsTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(null, NUMBER_ARRAY_CLASS, null));
+			assertNull(op.abstractEvaluate(null, TestUtilities.NUMBER_ARRAY_CLASS, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -78,89 +69,65 @@ public class ArrayEqualsTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testAbstractEvaluateMismatch()
 	{
-		assertTrue(op.abstractEvaluate(NUMBER_ARRAY_CLASS, BOOLEAN_ARRAY_CLASS,
+		ArrayEquals op = new ArrayEquals();
+		assertTrue(op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, TestUtilities.BOOLEAN_ARRAY_CLASS,
 			Optional.empty()).isEmpty());
-		assertTrue(op.abstractEvaluate(BOOLEAN_ARRAY_CLASS, INTEGER_ARRAY_CLASS,
-			Optional.of(booleanManager)).isEmpty());
-		assertTrue(op.abstractEvaluate(BOOLEAN_ARRAY_CLASS, INTEGER_CLASS,
-			Optional.of(booleanManager)).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_ARRAY_CLASS, NUMBER_CLASS,
-			Optional.of(booleanManager)).isEmpty());
+		assertTrue(op.abstractEvaluate(TestUtilities.BOOLEAN_ARRAY_CLASS, TestUtilities.INTEGER_ARRAY_CLASS,
+			Optional.of(FormatUtilities.BOOLEAN_MANAGER)).isEmpty());
+		assertTrue(op.abstractEvaluate(TestUtilities.BOOLEAN_ARRAY_CLASS, TestUtilities.INTEGER_CLASS,
+			Optional.of(FormatUtilities.BOOLEAN_MANAGER)).isEmpty());
+		assertTrue(op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, FormatUtilities.NUMBER_CLASS,
+			Optional.of(FormatUtilities.BOOLEAN_MANAGER)).isEmpty());
 	}
 
+	@Test
 	public void testAbstractEvaluateLegal()
 	{
-		assertEquals(BOOLEAN_CLASS, op.abstractEvaluate(NUMBER_ARRAY_CLASS,
-			NUMBER_ARRAY_CLASS, Optional.of(numberArrayManager)).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS, op.abstractEvaluate(BOOLEAN_ARRAY_CLASS,
-			BOOLEAN_ARRAY_CLASS, Optional.of(booleanArrayManager)).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(NUMBER_ARRAY_CLASS, NUMBER_ARRAY_CLASS, Optional.empty())
+		ArrayEquals op = new ArrayEquals();
+		assertEquals(FormatUtilities.BOOLEAN_CLASS, op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS,
+			TestUtilities.NUMBER_ARRAY_CLASS, Optional.of(TestUtilities.NUMBER_ARRAY_MANAGER)).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS, op.abstractEvaluate(TestUtilities.BOOLEAN_ARRAY_CLASS,
+			TestUtilities.BOOLEAN_ARRAY_CLASS, Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, TestUtilities.NUMBER_ARRAY_CLASS, Optional.empty())
 				.get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS, op
-			.abstractEvaluate(BOOLEAN_ARRAY_CLASS, BOOLEAN_ARRAY_CLASS, Optional.empty())
+		assertEquals(FormatUtilities.BOOLEAN_CLASS, op
+			.abstractEvaluate(TestUtilities.BOOLEAN_ARRAY_CLASS, TestUtilities.BOOLEAN_ARRAY_CLASS, Optional.empty())
 			.get().getManagedClass());
 	}
 
+	@Test
 	public void testEvaluateFailNull()
 	{
-		try
-		{
-			assertNull(op.evaluate(null, null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(Boolean.TRUE, null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(new Boolean[0], null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(null, Boolean.FALSE));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
+		ArrayEquals op = new ArrayEquals();
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(Boolean.TRUE, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(new Boolean[0], null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, Boolean.FALSE));
 	}
 
+	@Test
 	public void testEvaluateLegalArrayArray()
 	{
+		ArrayEquals op = new ArrayEquals();
 		Number[] iArray = new Number[]{1, 2};
 		Object result = op.evaluate(iArray, new Number[]{4.5, -6});
-		assertTrue(result.getClass().equals(BOOLEAN_CLASS));
+		assertTrue(result.getClass().equals(FormatUtilities.BOOLEAN_CLASS));
 		assertFalse((Boolean) result);
 		result = op.evaluate(iArray, new Number[]{1, -6});
-		assertTrue(result.getClass().equals(BOOLEAN_CLASS));
+		assertTrue(result.getClass().equals(FormatUtilities.BOOLEAN_CLASS));
 		assertFalse((Boolean) result);
 		result = op.evaluate(iArray, new Number[]{2, -6});
-		assertTrue(result.getClass().equals(BOOLEAN_CLASS));
+		assertTrue(result.getClass().equals(FormatUtilities.BOOLEAN_CLASS));
 		assertFalse((Boolean) result);
 		result = op.evaluate(iArray, new Number[]{1, 2});
-		assertTrue(result.getClass().equals(BOOLEAN_CLASS));
+		assertTrue(result.getClass().equals(FormatUtilities.BOOLEAN_CLASS));
 		assertTrue((Boolean) result);
 		result = op.evaluate(iArray, new Number[]{1, -6, 2});
-		assertTrue(result.getClass().equals(BOOLEAN_CLASS));
+		assertTrue(result.getClass().equals(FormatUtilities.BOOLEAN_CLASS));
 		assertFalse((Boolean) result);
 		/*
 		 * Today we respect order... this is up for debate, though
@@ -170,7 +137,7 @@ public class ArrayEqualsTest extends TestCase
 		 */
 		iArray = new Number[]{1, 2, 1};
 		result = op.evaluate(iArray, new Number[]{1, 1, 2});
-		assertTrue(result.getClass().equals(BOOLEAN_CLASS));
+		assertTrue(result.getClass().equals(FormatUtilities.BOOLEAN_CLASS));
 		assertFalse((Boolean) result);
 	}
 }

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/operator/array/ArrayNotEqualTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/operator/array/ArrayNotEqualTest.java
@@ -15,43 +15,34 @@
  */
 package pcgen.base.formula.operator.array;
 
-import java.lang.reflect.Array;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Optional;
 
-import junit.framework.TestCase;
-import pcgen.base.format.ArrayFormatManager;
-import pcgen.base.format.BooleanManager;
-import pcgen.base.format.NumberManager;
-import pcgen.base.util.FormatManager;
+import org.junit.jupiter.api.Test;
 
-public class ArrayNotEqualTest extends TestCase
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.testsupport.TestUtilities;
+
+public class ArrayNotEqualTest
 {
-
-	private static final Class<Number> NUMBER_CLASS = Number.class;
-	private static final Class<Boolean> BOOLEAN_CLASS = Boolean.class;
-	private static final Class<Integer> INTEGER_CLASS = Integer.class;
-	private static final Class<Number[]> NUMBER_ARRAY_CLASS =
-			(Class<Number[]>) Array.newInstance(NUMBER_CLASS, 0).getClass();
-	private static final Class<Boolean[]> BOOLEAN_ARRAY_CLASS =
-			(Class<Boolean[]>) Array.newInstance(BOOLEAN_CLASS, 0).getClass();
-	private static final Class<Integer[]> INTEGER_ARRAY_CLASS =
-			(Class<Integer[]>) Array.newInstance(INTEGER_CLASS, 0).getClass();
-	private final BooleanManager booleanManager = new BooleanManager();
-	private final FormatManager<Number[]> numberArrayManager =
-			new ArrayFormatManager<>(new NumberManager(), ',', '|');
-	private final FormatManager<Boolean[]> booleanArrayManager =
-			new ArrayFormatManager<>(booleanManager, ',', '|');
-
-	private final ArrayNotEqual op = new ArrayNotEqual();
-
+	@Test
 	public void testOperator()
 	{
+		ArrayNotEqual op = new ArrayNotEqual();
 		assertNotNull(op.getOperator());
 		assertTrue(op.getOperator().getSymbol().equals("!="));
 	}
 
+	@Test
 	public void testAbstractEvaluateNulls()
 	{
+		ArrayNotEqual op = new ArrayNotEqual();
 		try
 		{
 			assertNull(op.abstractEvaluate(null, null, null));
@@ -62,7 +53,7 @@ public class ArrayNotEqualTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(NUMBER_ARRAY_CLASS, null, null));
+			assertNull(op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, null, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -70,7 +61,7 @@ public class ArrayNotEqualTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(null, NUMBER_ARRAY_CLASS, null));
+			assertNull(op.abstractEvaluate(null, TestUtilities.NUMBER_ARRAY_CLASS, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -78,89 +69,65 @@ public class ArrayNotEqualTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testAbstractEvaluateMismatch()
 	{
-		assertTrue(op.abstractEvaluate(NUMBER_ARRAY_CLASS, BOOLEAN_ARRAY_CLASS,
+		ArrayNotEqual op = new ArrayNotEqual();
+		assertTrue(op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, TestUtilities.BOOLEAN_ARRAY_CLASS,
 			Optional.empty()).isEmpty());
-		assertTrue(op.abstractEvaluate(BOOLEAN_ARRAY_CLASS, INTEGER_ARRAY_CLASS,
-			Optional.of(booleanManager)).isEmpty());
-		assertTrue(op.abstractEvaluate(BOOLEAN_ARRAY_CLASS, INTEGER_CLASS,
-			Optional.of(booleanManager)).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_ARRAY_CLASS, NUMBER_CLASS,
-			Optional.of(booleanManager)).isEmpty());
+		assertTrue(op.abstractEvaluate(TestUtilities.BOOLEAN_ARRAY_CLASS, TestUtilities.INTEGER_ARRAY_CLASS,
+			Optional.of(FormatUtilities.BOOLEAN_MANAGER)).isEmpty());
+		assertTrue(op.abstractEvaluate(TestUtilities.BOOLEAN_ARRAY_CLASS, TestUtilities.INTEGER_CLASS,
+			Optional.of(FormatUtilities.BOOLEAN_MANAGER)).isEmpty());
+		assertTrue(op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, FormatUtilities.NUMBER_CLASS,
+			Optional.of(FormatUtilities.BOOLEAN_MANAGER)).isEmpty());
 	}
 
+	@Test
 	public void testAbstractEvaluateLegal()
 	{
-		assertEquals(BOOLEAN_CLASS, op.abstractEvaluate(NUMBER_ARRAY_CLASS,
-			NUMBER_ARRAY_CLASS, Optional.of(numberArrayManager)).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS, op.abstractEvaluate(BOOLEAN_ARRAY_CLASS,
-			BOOLEAN_ARRAY_CLASS, Optional.of(booleanArrayManager)).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(NUMBER_ARRAY_CLASS, NUMBER_ARRAY_CLASS, Optional.empty())
+		ArrayNotEqual op = new ArrayNotEqual();
+		assertEquals(FormatUtilities.BOOLEAN_CLASS, op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS,
+			TestUtilities.NUMBER_ARRAY_CLASS, Optional.of(TestUtilities.NUMBER_ARRAY_MANAGER)).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS, op.abstractEvaluate(TestUtilities.BOOLEAN_ARRAY_CLASS,
+			TestUtilities.BOOLEAN_ARRAY_CLASS, Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, TestUtilities.NUMBER_ARRAY_CLASS, Optional.empty())
 			.get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS, op
-			.abstractEvaluate(BOOLEAN_ARRAY_CLASS, BOOLEAN_ARRAY_CLASS, Optional.empty())
+		assertEquals(FormatUtilities.BOOLEAN_CLASS, op
+			.abstractEvaluate(TestUtilities.BOOLEAN_ARRAY_CLASS, TestUtilities.BOOLEAN_ARRAY_CLASS, Optional.empty())
 			.get().getManagedClass());
 	}
 
+	@Test
 	public void testEvaluateFailNull()
 	{
-		try
-		{
-			assertNull(op.evaluate(null, null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(Boolean.TRUE, null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(new Boolean[0], null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(null, Boolean.FALSE));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
+		ArrayNotEqual op = new ArrayNotEqual();
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(Boolean.TRUE, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(new Boolean[0], null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, Boolean.FALSE));
 	}
 
+	@Test
 	public void testEvaluateLegalArrayArray()
 	{
+		ArrayNotEqual op = new ArrayNotEqual();
 		Number[] iArray = new Number[]{1, 2};
 		Object result = op.evaluate(iArray, new Number[]{4.5, -6});
-		assertTrue(result.getClass().equals(BOOLEAN_CLASS));
+		assertTrue(result.getClass().equals(FormatUtilities.BOOLEAN_CLASS));
 		assertTrue((Boolean) result);
 		result = op.evaluate(iArray, new Number[]{1, -6});
-		assertTrue(result.getClass().equals(BOOLEAN_CLASS));
+		assertTrue(result.getClass().equals(FormatUtilities.BOOLEAN_CLASS));
 		assertTrue((Boolean) result);
 		result = op.evaluate(iArray, new Number[]{2, -6});
-		assertTrue(result.getClass().equals(BOOLEAN_CLASS));
+		assertTrue(result.getClass().equals(FormatUtilities.BOOLEAN_CLASS));
 		assertTrue((Boolean) result);
 		result = op.evaluate(iArray, new Number[]{1, 2});
-		assertTrue(result.getClass().equals(BOOLEAN_CLASS));
+		assertTrue(result.getClass().equals(FormatUtilities.BOOLEAN_CLASS));
 		assertFalse((Boolean) result);
 		result = op.evaluate(iArray, new Number[]{1, -6, 2});
-		assertTrue(result.getClass().equals(BOOLEAN_CLASS));
+		assertTrue(result.getClass().equals(FormatUtilities.BOOLEAN_CLASS));
 		assertTrue((Boolean) result);
 		/*
 		 * Today we respect order... this is up for debate, though
@@ -170,7 +137,7 @@ public class ArrayNotEqualTest extends TestCase
 		 */
 		iArray = new Number[]{1, 2, 1};
 		result = op.evaluate(iArray, new Number[]{1, 1, 2});
-		assertTrue(result.getClass().equals(BOOLEAN_CLASS));
+		assertTrue(result.getClass().equals(FormatUtilities.BOOLEAN_CLASS));
 		assertTrue((Boolean) result);
 	}
 }

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/operator/array/ArraySubtractInstanceTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/operator/array/ArraySubtractInstanceTest.java
@@ -15,44 +15,33 @@
  */
 package pcgen.base.formula.operator.array;
 
-import java.lang.reflect.Array;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Optional;
 
-import junit.framework.TestCase;
-import pcgen.base.format.ArrayFormatManager;
-import pcgen.base.format.BooleanManager;
-import pcgen.base.format.NumberManager;
-import pcgen.base.util.FormatManager;
+import org.junit.jupiter.api.Test;
 
-public class ArraySubtractInstanceTest extends TestCase
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.testsupport.TestUtilities;
+
+public class ArraySubtractInstanceTest
 {
-
-	private static final Class<Number> NUMBER_CLASS = Number.class;
-	private static final Class<Boolean> BOOLEAN_CLASS = Boolean.class;
-	private static final Class<Integer> INTEGER_CLASS = Integer.class;
-	private static final Class<Object[]> OBJECT_ARRAY_CLASS =
-			(Class<Object[]>) Array.newInstance(Object.class, 0).getClass();
-	private static final Class<Number[]> NUMBER_ARRAY_CLASS =
-			(Class<Number[]>) Array.newInstance(NUMBER_CLASS, 0).getClass();
-	private static final Class<Boolean[]> BOOLEAN_ARRAY_CLASS =
-			(Class<Boolean[]>) Array.newInstance(BOOLEAN_CLASS, 0).getClass();
-	private static final Class<Integer[]> INTEGER_ARRAY_CLASS =
-			(Class<Integer[]>) Array.newInstance(INTEGER_CLASS, 0).getClass();
-	FormatManager<Number[]> numberArrayManager =
-			new ArrayFormatManager<>(new NumberManager(), ',', '|');
-	FormatManager<Boolean[]> booleanArrayManager =
-			new ArrayFormatManager<>(new BooleanManager(), ',', '|');
-
-	private final ArraySubtractInstance op = new ArraySubtractInstance();
-
+	@Test
 	public void testOperator()
 	{
+		ArraySubtractInstance op = new ArraySubtractInstance();
 		assertNotNull(op.getOperator());
 		assertTrue(op.getOperator().getSymbol().equals("%"));
 	}
 
+	@Test
 	public void testAbstractEvaluateNulls()
 	{
+		ArraySubtractInstance op = new ArraySubtractInstance();
 		try
 		{
 			assertNull(op.abstractEvaluate(null, null, null));
@@ -63,7 +52,7 @@ public class ArraySubtractInstanceTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(NUMBER_ARRAY_CLASS, null, null));
+			assertNull(op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, null, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -71,7 +60,7 @@ public class ArraySubtractInstanceTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(null, NUMBER_ARRAY_CLASS, null));
+			assertNull(op.abstractEvaluate(null, TestUtilities.NUMBER_ARRAY_CLASS, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -79,7 +68,7 @@ public class ArraySubtractInstanceTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(NUMBER_ARRAY_CLASS, NUMBER_ARRAY_CLASS, null));
+			assertNull(op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, TestUtilities.NUMBER_ARRAY_CLASS, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -87,38 +76,42 @@ public class ArraySubtractInstanceTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testAbstractEvaluateMismatch()
 	{
-		assertTrue(op.abstractEvaluate(NUMBER_ARRAY_CLASS, BOOLEAN_ARRAY_CLASS,
+		ArraySubtractInstance op = new ArraySubtractInstance();
+		assertTrue(op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, TestUtilities.BOOLEAN_ARRAY_CLASS,
 			Optional.empty()).isEmpty());
-		assertTrue(op.abstractEvaluate(BOOLEAN_ARRAY_CLASS, INTEGER_ARRAY_CLASS,
-			Optional.of(booleanArrayManager)).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_ARRAY_CLASS, NUMBER_ARRAY_CLASS,
-			Optional.of(booleanArrayManager)).isEmpty());
-		assertTrue(op.abstractEvaluate(BOOLEAN_ARRAY_CLASS, INTEGER_CLASS,
-			Optional.of(booleanArrayManager)).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_ARRAY_CLASS, NUMBER_CLASS,
-			Optional.of(booleanArrayManager)).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_CLASS, NUMBER_ARRAY_CLASS,
-			Optional.of(numberArrayManager)).isEmpty());
-		assertTrue(op.abstractEvaluate(BOOLEAN_CLASS, BOOLEAN_ARRAY_CLASS,
-			Optional.of(booleanArrayManager)).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_CLASS, NUMBER_CLASS,
-			Optional.of(numberArrayManager)).isEmpty());
-		assertTrue(op.abstractEvaluate(BOOLEAN_CLASS, BOOLEAN_CLASS,
-			Optional.of(booleanArrayManager)).isEmpty());
+		assertTrue(op.abstractEvaluate(TestUtilities.BOOLEAN_ARRAY_CLASS, TestUtilities.INTEGER_ARRAY_CLASS,
+			Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).isEmpty());
+		assertTrue(op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, TestUtilities.NUMBER_ARRAY_CLASS,
+			Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).isEmpty());
+		assertTrue(op.abstractEvaluate(TestUtilities.BOOLEAN_ARRAY_CLASS, TestUtilities.INTEGER_CLASS,
+			Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).isEmpty());
+		assertTrue(op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, FormatUtilities.NUMBER_CLASS,
+			Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, TestUtilities.NUMBER_ARRAY_CLASS,
+			Optional.of(TestUtilities.NUMBER_ARRAY_MANAGER)).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, TestUtilities.BOOLEAN_ARRAY_CLASS,
+			Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.NUMBER_CLASS,
+			Optional.of(TestUtilities.NUMBER_ARRAY_MANAGER)).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, FormatUtilities.BOOLEAN_CLASS,
+			Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).isEmpty());
 	}
 
+	@Test
 	public void testAbstractEvaluateLegal()
 	{
-		assertEquals(NUMBER_ARRAY_CLASS, op.abstractEvaluate(NUMBER_ARRAY_CLASS,
-			NUMBER_ARRAY_CLASS, Optional.of(numberArrayManager)).get().getManagedClass());
-		assertEquals(BOOLEAN_ARRAY_CLASS, op.abstractEvaluate(BOOLEAN_ARRAY_CLASS,
-			BOOLEAN_ARRAY_CLASS, Optional.of(booleanArrayManager)).get().getManagedClass());
-		assertEquals(NUMBER_ARRAY_CLASS, op.abstractEvaluate(NUMBER_ARRAY_CLASS,
-			NUMBER_CLASS, Optional.of(numberArrayManager)).get().getManagedClass());
-		assertEquals(BOOLEAN_ARRAY_CLASS, op.abstractEvaluate(BOOLEAN_ARRAY_CLASS,
-			BOOLEAN_CLASS, Optional.of(booleanArrayManager)).get().getManagedClass());
+		ArraySubtractInstance op = new ArraySubtractInstance();
+		assertEquals(TestUtilities.NUMBER_ARRAY_CLASS, op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS,
+			TestUtilities.NUMBER_ARRAY_CLASS, Optional.of(TestUtilities.NUMBER_ARRAY_MANAGER)).get().getManagedClass());
+		assertEquals(TestUtilities.BOOLEAN_ARRAY_CLASS, op.abstractEvaluate(TestUtilities.BOOLEAN_ARRAY_CLASS,
+			TestUtilities.BOOLEAN_ARRAY_CLASS, Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).get().getManagedClass());
+		assertEquals(TestUtilities.NUMBER_ARRAY_CLASS, op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS,
+			FormatUtilities.NUMBER_CLASS, Optional.of(TestUtilities.NUMBER_ARRAY_MANAGER)).get().getManagedClass());
+		assertEquals(TestUtilities.BOOLEAN_ARRAY_CLASS, op.abstractEvaluate(TestUtilities.BOOLEAN_ARRAY_CLASS,
+			FormatUtilities.BOOLEAN_CLASS, Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).get().getManagedClass());
 		//TODO Interesting that these REQUIRE a format assertion... why?
 //		assertEquals(NUMBER_ARRAY_CLASS,
 //			op.abstractEvaluate(NUMBER_ARRAY_CLASS, NUMBER_ARRAY_CLASS, Optional.empty())
@@ -128,51 +121,23 @@ public class ArraySubtractInstanceTest extends TestCase
 //			.getManagedClass());
 	}
 
+	@Test
 	public void testEvaluateFailNull()
 	{
-		try
-		{
-			assertNull(op.evaluate(null, null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(Boolean.TRUE, null));
-			fail();
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(new Boolean[0], null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(null, Boolean.FALSE));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
+		ArraySubtractInstance op = new ArraySubtractInstance();
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, null));
+		assertThrows(IllegalArgumentException.class, () -> op.evaluate(Boolean.TRUE, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(new Boolean[0], null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, Boolean.FALSE));
 	}
 
+	@Test
 	public void testEvaluateLegalArrayObject()
 	{
+		ArraySubtractInstance op = new ArraySubtractInstance();
 		Number[] iArray = new Number[]{1, 2, 4.5, -6};
 		Object result = op.evaluate(iArray, 2);
-		assertTrue(result.getClass().equals(OBJECT_ARRAY_CLASS));
+		assertTrue(result.getClass().equals(TestUtilities.OBJECT_ARRAY_CLASS));
 		Object[] resultArray = (Object[]) result;
 		assertEquals(3, resultArray.length);
 		assertEquals(1, resultArray[0]);
@@ -180,11 +145,13 @@ public class ArraySubtractInstanceTest extends TestCase
 		assertEquals(-6, resultArray[2]);
 	}
 
+	@Test
 	public void testEvaluateLegalArrayArray()
 	{
+		ArraySubtractInstance op = new ArraySubtractInstance();
 		Number[] iArray = new Number[]{1, 2, 4.5, -6};
 		Object result = op.evaluate(iArray, new Number[]{1, 2});
-		assertTrue(result.getClass().equals(OBJECT_ARRAY_CLASS));
+		assertTrue(result.getClass().equals(TestUtilities.OBJECT_ARRAY_CLASS));
 		Object[] resultArray = (Object[]) result;
 		assertEquals(2, resultArray.length);
 		assertEquals(4.5, resultArray[0]);
@@ -192,7 +159,7 @@ public class ArraySubtractInstanceTest extends TestCase
 		//Respect duplicates
 		iArray = new Number[]{1, 2, 4.5, 1};
 		result = op.evaluate(iArray, new Number[]{1, 2});
-		assertTrue(result.getClass().equals(OBJECT_ARRAY_CLASS));
+		assertTrue(result.getClass().equals(TestUtilities.OBJECT_ARRAY_CLASS));
 		resultArray = (Object[]) result;
 		assertEquals(2, resultArray.length);
 		assertEquals(4.5, resultArray[0]);
@@ -200,7 +167,7 @@ public class ArraySubtractInstanceTest extends TestCase
 		//Respect identity
 		iArray = new Number[]{new Integer(1), 2, 4.5};
 		result = op.evaluate(iArray, new Number[]{new Integer(1), 2});
-		assertTrue(result.getClass().equals(OBJECT_ARRAY_CLASS));
+		assertTrue(result.getClass().equals(TestUtilities.OBJECT_ARRAY_CLASS));
 		resultArray = (Object[]) result;
 		assertEquals(2, resultArray.length);
 		assertEquals(1, resultArray[0]);

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/operator/array/ArraySubtractTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/operator/array/ArraySubtractTest.java
@@ -15,44 +15,33 @@
  */
 package pcgen.base.formula.operator.array;
 
-import java.lang.reflect.Array;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Optional;
 
-import junit.framework.TestCase;
-import pcgen.base.format.ArrayFormatManager;
-import pcgen.base.format.BooleanManager;
-import pcgen.base.format.NumberManager;
-import pcgen.base.util.FormatManager;
+import org.junit.jupiter.api.Test;
 
-public class ArraySubtractTest extends TestCase
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.testsupport.TestUtilities;
+
+public class ArraySubtractTest
 {
-
-	private static final Class<Number> NUMBER_CLASS = Number.class;
-	private static final Class<Boolean> BOOLEAN_CLASS = Boolean.class;
-	private static final Class<Integer> INTEGER_CLASS = Integer.class;
-	private static final Class<Object[]> OBJECT_ARRAY_CLASS =
-			(Class<Object[]>) Array.newInstance(Object.class, 0).getClass();
-	private static final Class<Number[]> NUMBER_ARRAY_CLASS =
-			(Class<Number[]>) Array.newInstance(NUMBER_CLASS, 0).getClass();
-	private static final Class<Boolean[]> BOOLEAN_ARRAY_CLASS =
-			(Class<Boolean[]>) Array.newInstance(BOOLEAN_CLASS, 0).getClass();
-	private static final Class<Integer[]> INTEGER_ARRAY_CLASS =
-			(Class<Integer[]>) Array.newInstance(INTEGER_CLASS, 0).getClass();
-	FormatManager<Number[]> numberArrayManager =
-			new ArrayFormatManager<>(new NumberManager(), ',', '|');
-	FormatManager<Boolean[]> booleanArrayManager =
-			new ArrayFormatManager<>(new BooleanManager(), ',', '|');
-
-	private final ArraySubtract op = new ArraySubtract();
-
+	@Test
 	public void testOperator()
 	{
+		ArraySubtract op = new ArraySubtract();
 		assertNotNull(op.getOperator());
 		assertTrue(op.getOperator().getSymbol().equals("-"));
 	}
 
+	@Test
 	public void testAbstractEvaluateNulls()
 	{
+		ArraySubtract op = new ArraySubtract();
 		try
 		{
 			assertNull(op.abstractEvaluate(null, null, null));
@@ -63,7 +52,7 @@ public class ArraySubtractTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(NUMBER_ARRAY_CLASS, null, null));
+			assertNull(op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, null, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -71,7 +60,7 @@ public class ArraySubtractTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(null, NUMBER_ARRAY_CLASS, null));
+			assertNull(op.abstractEvaluate(null, TestUtilities.NUMBER_ARRAY_CLASS, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -79,7 +68,7 @@ public class ArraySubtractTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(NUMBER_ARRAY_CLASS, NUMBER_ARRAY_CLASS, null));
+			assertNull(op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, TestUtilities.NUMBER_ARRAY_CLASS, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -87,38 +76,42 @@ public class ArraySubtractTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testAbstractEvaluateMismatch()
 	{
-		assertTrue(op.abstractEvaluate(NUMBER_ARRAY_CLASS, BOOLEAN_ARRAY_CLASS,
+		ArraySubtract op = new ArraySubtract();
+		assertTrue(op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, TestUtilities.BOOLEAN_ARRAY_CLASS,
 			Optional.empty()).isEmpty());
-		assertTrue(op.abstractEvaluate(BOOLEAN_ARRAY_CLASS, INTEGER_ARRAY_CLASS,
-			Optional.of(booleanArrayManager)).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_ARRAY_CLASS, NUMBER_ARRAY_CLASS,
-			Optional.of(booleanArrayManager)).isEmpty());
-		assertTrue(op.abstractEvaluate(BOOLEAN_ARRAY_CLASS, INTEGER_CLASS,
-			Optional.of(booleanArrayManager)).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_ARRAY_CLASS, NUMBER_CLASS,
-			Optional.of(booleanArrayManager)).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_CLASS, NUMBER_ARRAY_CLASS,
-			Optional.of(numberArrayManager)).isEmpty());
-		assertTrue(op.abstractEvaluate(BOOLEAN_CLASS, BOOLEAN_ARRAY_CLASS,
-			Optional.of(booleanArrayManager)).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_CLASS, NUMBER_CLASS,
-			Optional.of(numberArrayManager)).isEmpty());
-		assertTrue(op.abstractEvaluate(BOOLEAN_CLASS, BOOLEAN_CLASS,
-			Optional.of(booleanArrayManager)).isEmpty());
+		assertTrue(op.abstractEvaluate(TestUtilities.BOOLEAN_ARRAY_CLASS, TestUtilities.INTEGER_ARRAY_CLASS,
+			Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).isEmpty());
+		assertTrue(op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, TestUtilities.NUMBER_ARRAY_CLASS,
+			Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).isEmpty());
+		assertTrue(op.abstractEvaluate(TestUtilities.BOOLEAN_ARRAY_CLASS, TestUtilities.INTEGER_CLASS,
+			Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).isEmpty());
+		assertTrue(op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, FormatUtilities.NUMBER_CLASS,
+			Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, TestUtilities.NUMBER_ARRAY_CLASS,
+			Optional.of(TestUtilities.NUMBER_ARRAY_MANAGER)).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, TestUtilities.BOOLEAN_ARRAY_CLASS,
+			Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.NUMBER_CLASS,
+			Optional.of(TestUtilities.NUMBER_ARRAY_MANAGER)).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, FormatUtilities.BOOLEAN_CLASS,
+			Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).isEmpty());
 	}
 
+	@Test
 	public void testAbstractEvaluateLegal()
 	{
-		assertEquals(NUMBER_ARRAY_CLASS, op.abstractEvaluate(NUMBER_ARRAY_CLASS,
-			NUMBER_ARRAY_CLASS, Optional.of(numberArrayManager)).get().getManagedClass());
-		assertEquals(BOOLEAN_ARRAY_CLASS, op.abstractEvaluate(BOOLEAN_ARRAY_CLASS,
-			BOOLEAN_ARRAY_CLASS, Optional.of(booleanArrayManager)).get().getManagedClass());
-		assertEquals(NUMBER_ARRAY_CLASS, op.abstractEvaluate(NUMBER_ARRAY_CLASS,
-			NUMBER_CLASS, Optional.of(numberArrayManager)).get().getManagedClass());
-		assertEquals(BOOLEAN_ARRAY_CLASS, op.abstractEvaluate(BOOLEAN_ARRAY_CLASS,
-			BOOLEAN_CLASS, Optional.of(booleanArrayManager)).get().getManagedClass());
+		ArraySubtract op = new ArraySubtract();
+		assertEquals(TestUtilities.NUMBER_ARRAY_CLASS, op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS,
+			TestUtilities.NUMBER_ARRAY_CLASS, Optional.of(TestUtilities.NUMBER_ARRAY_MANAGER)).get().getManagedClass());
+		assertEquals(TestUtilities.BOOLEAN_ARRAY_CLASS, op.abstractEvaluate(TestUtilities.BOOLEAN_ARRAY_CLASS,
+			TestUtilities.BOOLEAN_ARRAY_CLASS, Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).get().getManagedClass());
+		assertEquals(TestUtilities.NUMBER_ARRAY_CLASS, op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS,
+			FormatUtilities.NUMBER_CLASS, Optional.of(TestUtilities.NUMBER_ARRAY_MANAGER)).get().getManagedClass());
+		assertEquals(TestUtilities.BOOLEAN_ARRAY_CLASS, op.abstractEvaluate(TestUtilities.BOOLEAN_ARRAY_CLASS,
+			FormatUtilities.BOOLEAN_CLASS, Optional.of(TestUtilities.BOOLEAN_ARRAY_MANAGER)).get().getManagedClass());
 		//TODO Interesting that these REQUIRE a format assertion... why?
 //		assertEquals(NUMBER_ARRAY_CLASS,
 //			op.abstractEvaluate(NUMBER_ARRAY_CLASS, NUMBER_ARRAY_CLASS, Optional.empty())
@@ -128,51 +121,23 @@ public class ArraySubtractTest extends TestCase
 //			.getManagedClass());
 	}
 
+	@Test
 	public void testEvaluateFailNull()
 	{
-		try
-		{
-			assertNull(op.evaluate(null, null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(Boolean.TRUE, null));
-			fail();
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(new Boolean[0], null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(null, Boolean.FALSE));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
+		ArraySubtract op = new ArraySubtract();
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, null));
+		assertThrows(IllegalArgumentException.class, () -> op.evaluate(Boolean.TRUE, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(new Boolean[0], null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, Boolean.FALSE));
 	}
 
+	@Test
 	public void testEvaluateLegalArrayObject()
 	{
+		ArraySubtract op = new ArraySubtract();
 		Number[] iArray = new Number[]{1, 2, 4.5, -6};
 		Object result = op.evaluate(iArray, 2);
-		assertTrue(result.getClass().equals(OBJECT_ARRAY_CLASS));
+		assertTrue(result.getClass().equals(TestUtilities.OBJECT_ARRAY_CLASS));
 		Object[] resultArray = (Object[]) result;
 		assertEquals(3, resultArray.length);
 		assertEquals(1, resultArray[0]);
@@ -180,11 +145,13 @@ public class ArraySubtractTest extends TestCase
 		assertEquals(-6, resultArray[2]);
 	}
 
+	@Test
 	public void testEvaluateLegalArrayArray()
 	{
+		ArraySubtract op = new ArraySubtract();
 		Number[] iArray = new Number[]{1, 2, 4.5, -6};
 		Object result = op.evaluate(iArray, new Number[]{1, 2});
-		assertTrue(result.getClass().equals(OBJECT_ARRAY_CLASS));
+		assertTrue(result.getClass().equals(TestUtilities.OBJECT_ARRAY_CLASS));
 		Object[] resultArray = (Object[]) result;
 		assertEquals(2, resultArray.length);
 		assertEquals(4.5, resultArray[0]);
@@ -192,7 +159,7 @@ public class ArraySubtractTest extends TestCase
 		//Respect duplicates
 		iArray = new Number[]{1, 2, 4.5, 1};
 		result = op.evaluate(iArray, new Number[]{1, 2});
-		assertTrue(result.getClass().equals(OBJECT_ARRAY_CLASS));
+		assertTrue(result.getClass().equals(TestUtilities.OBJECT_ARRAY_CLASS));
 		resultArray = (Object[]) result;
 		assertEquals(2, resultArray.length);
 		assertEquals(4.5, resultArray[0]);

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/operator/bool/BooleanAndTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/operator/bool/BooleanAndTest.java
@@ -17,25 +17,31 @@
  */
 package pcgen.base.formula.operator.bool;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BooleanAndTest extends TestCase
+import org.junit.jupiter.api.Test;
+
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.testsupport.TestUtilities;
+
+public class BooleanAndTest
 {
-
-	private static final Class<Number> NUMBER_CLASS = Number.class;
-	private static final Class<Boolean> BOOLEAN_CLASS = Boolean.class;
-	private static final Class<Integer> INTEGER_CLASS = Integer.class;
-
-	private final BooleanAnd op = new BooleanAnd();
-
+	@Test
 	public void testOperator()
 	{
+		BooleanAnd op = new BooleanAnd();
 		assertNotNull(op.getOperator());
 		assertTrue(op.getOperator().getSymbol().equals("&&"));
 	}
 
+	@Test
 	public void testAbstractEvaluateNulls()
 	{
+		BooleanAnd op = new BooleanAnd();
 		try
 		{
 			assertNull(op.abstractEvaluate(null, null, null));
@@ -46,7 +52,7 @@ public class BooleanAndTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(BOOLEAN_CLASS, null, null));
+			assertNull(op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, null, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -54,7 +60,7 @@ public class BooleanAndTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(null, BOOLEAN_CLASS, null));
+			assertNull(op.abstractEvaluate(null, FormatUtilities.BOOLEAN_CLASS, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -62,73 +68,43 @@ public class BooleanAndTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testAbstractEvaluateMismatch()
 	{
-		assertTrue(op.abstractEvaluate(BOOLEAN_CLASS, INTEGER_CLASS, null).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_CLASS, BOOLEAN_CLASS, null).isEmpty());
+		BooleanAnd op = new BooleanAnd();
+		assertTrue(op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, TestUtilities.INTEGER_CLASS, null).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.BOOLEAN_CLASS, null).isEmpty());
 	}
 
+	@Test
 	public void testAbstractEvaluateLegal()
 	{
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(BOOLEAN_CLASS, BOOLEAN_CLASS, null).get().getManagedClass());
+		BooleanAnd op = new BooleanAnd();
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, FormatUtilities.BOOLEAN_CLASS, null).get().getManagedClass());
 	}
 
+	@Test
 	public void testEvaluateFailNull()
 	{
-		try
-		{
-			assertNull(op.evaluate(null, null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(Boolean.TRUE, null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(null, Boolean.FALSE));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
+		BooleanAnd op = new BooleanAnd();
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(Boolean.TRUE, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, Boolean.FALSE));
 	}
 
+	@Test
 	public void testEvaluateMismatch()
 	{
-		try
-		{
-			assertNull(op.evaluate(Boolean.FALSE, Double.valueOf(4.5)));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(new Object(), Boolean.TRUE));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
+		BooleanAnd op = new BooleanAnd();
+		assertThrows(ClassCastException.class, () -> op.evaluate(Boolean.FALSE, Double.valueOf(4.5)));
+		assertThrows(ClassCastException.class, () -> op.evaluate(new Object(), Boolean.TRUE));
 	}
 
+	@Test
 	public void testEvaluateLegal()
 	{
+		BooleanAnd op = new BooleanAnd();
 		assertEquals(Boolean.TRUE, op.evaluate(Boolean.TRUE, Boolean.TRUE));
 		assertEquals(Boolean.FALSE, op.evaluate(Boolean.FALSE, Boolean.TRUE));
 		assertEquals(Boolean.FALSE, op.evaluate(Boolean.TRUE, Boolean.FALSE));

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/operator/bool/BooleanNotTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/operator/bool/BooleanNotTest.java
@@ -17,25 +17,31 @@
  */
 package pcgen.base.formula.operator.bool;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BooleanNotTest extends TestCase
+import org.junit.jupiter.api.Test;
+
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.testsupport.TestUtilities;
+
+public class BooleanNotTest
 {
-
-	private static final Class<Number> NUMBER_CLASS = Number.class;
-	private static final Class<Boolean> BOOLEAN_CLASS = Boolean.class;
-	private static final Class<Integer> INTEGER_CLASS = Integer.class;
-
-	private final BooleanNot op = new BooleanNot();
-
+	@Test
 	public void testOperator()
 	{
+		BooleanNot op = new BooleanNot();
 		assertNotNull(op.getOperator());
 		assertTrue(op.getOperator().getSymbol().equals("!"));
 	}
 
+	@Test
 	public void testAbstractEvaluateNulls()
 	{
+		BooleanNot op = new BooleanNot();
 		try
 		{
 			assertNull(op.abstractEvaluate(null));
@@ -46,54 +52,40 @@ public class BooleanNotTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testAbstractEvaluateMismatch()
 	{
-		assertTrue(op.abstractEvaluate(INTEGER_CLASS).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_CLASS).isEmpty());
+		BooleanNot op = new BooleanNot();
+		assertTrue(op.abstractEvaluate(TestUtilities.INTEGER_CLASS).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS).isEmpty());
 	}
 
+	@Test
 	public void testAbstractEvaluateLegal()
 	{
-		assertEquals(BOOLEAN_CLASS, op.abstractEvaluate(BOOLEAN_CLASS).get().getManagedClass());
+		BooleanNot op = new BooleanNot();
+		assertEquals(FormatUtilities.BOOLEAN_CLASS, op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS).get().getManagedClass());
 	}
 
+	@Test
 	public void testEvaluateFailNull()
 	{
-		try
-		{
-			assertNull(op.evaluate(null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
+		BooleanNot op = new BooleanNot();
+		assertThrows(NullPointerException.class, () -> op.evaluate(null));
 	}
 
+	@Test
 	public void testEvaluateMismatch()
 	{
-		try
-		{
-			assertNull(op.evaluate(Double.valueOf(4.5)));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(new Object()));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
+		BooleanNot op = new BooleanNot();
+		assertThrows(ClassCastException.class, () -> op.evaluate(Double.valueOf(4.5)));
+		assertThrows(ClassCastException.class, () -> op.evaluate(new Object()));
 	}
 
+	@Test
 	public void testEvaluateLegal()
 	{
+		BooleanNot op = new BooleanNot();
 		assertEquals(Boolean.TRUE, op.evaluate(Boolean.FALSE));
 		assertEquals(Boolean.FALSE, op.evaluate(Boolean.TRUE));
 	}

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/operator/bool/BooleanOrTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/operator/bool/BooleanOrTest.java
@@ -17,25 +17,31 @@
  */
 package pcgen.base.formula.operator.bool;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BooleanOrTest extends TestCase
+import org.junit.jupiter.api.Test;
+
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.testsupport.TestUtilities;
+
+public class BooleanOrTest
 {
-
-	private static final Class<Number> NUMBER_CLASS = Number.class;
-	private static final Class<Boolean> BOOLEAN_CLASS = Boolean.class;
-	private static final Class<Integer> INTEGER_CLASS = Integer.class;
-
-	private final BooleanOr op = new BooleanOr();
-
+	@Test
 	public void testOperator()
 	{
+		BooleanOr op = new BooleanOr();
 		assertNotNull(op.getOperator());
 		assertTrue(op.getOperator().getSymbol().equals("||"));
 	}
 
+	@Test
 	public void testAbstractEvaluateNulls()
 	{
+		BooleanOr op = new BooleanOr();
 		try
 		{
 			assertNull(op.abstractEvaluate(null, null, null));
@@ -46,7 +52,7 @@ public class BooleanOrTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(BOOLEAN_CLASS, null, null));
+			assertNull(op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, null, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -54,7 +60,7 @@ public class BooleanOrTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(null, BOOLEAN_CLASS, null));
+			assertNull(op.abstractEvaluate(null, FormatUtilities.BOOLEAN_CLASS, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -62,73 +68,43 @@ public class BooleanOrTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testAbstractEvaluateMismatch()
 	{
-		assertTrue(op.abstractEvaluate(BOOLEAN_CLASS, INTEGER_CLASS, null).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_CLASS, BOOLEAN_CLASS, null).isEmpty());
+		BooleanOr op = new BooleanOr();
+		assertTrue(op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, TestUtilities.INTEGER_CLASS, null).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.BOOLEAN_CLASS, null).isEmpty());
 	}
 
+	@Test
 	public void testAbstractEvaluateLegal()
 	{
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(BOOLEAN_CLASS, BOOLEAN_CLASS, null).get().getManagedClass());
+		BooleanOr op = new BooleanOr();
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, FormatUtilities.BOOLEAN_CLASS, null).get().getManagedClass());
 	}
 
+	@Test
 	public void testEvaluateFailNull()
 	{
-		try
-		{
-			assertNull(op.evaluate(null, null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(Boolean.TRUE, null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(null, Boolean.FALSE));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
+		BooleanOr op = new BooleanOr();
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(Boolean.TRUE, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, Boolean.FALSE));
 	}
 
+	@Test
 	public void testEvaluateMismatch()
 	{
-		try
-		{
-			assertNull(op.evaluate(Boolean.TRUE, Double.valueOf(4.5)));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(new Object(), Boolean.FALSE));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
+		BooleanOr op = new BooleanOr();
+		assertThrows(ClassCastException.class, () -> op.evaluate(Boolean.TRUE, Double.valueOf(4.5)));
+		assertThrows(ClassCastException.class, () -> op.evaluate(new Object(), Boolean.FALSE));
 	}
 
+	@Test
 	public void testEvaluateLegal()
 	{
+		BooleanOr op = new BooleanOr();
 		assertEquals(Boolean.TRUE, op.evaluate(Boolean.TRUE, Boolean.TRUE));
 		assertEquals(Boolean.TRUE, op.evaluate(Boolean.FALSE, Boolean.TRUE));
 		assertEquals(Boolean.TRUE, op.evaluate(Boolean.TRUE, Boolean.FALSE));

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/operator/generic/GenericEqualsTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/operator/generic/GenericEqualsTest.java
@@ -17,29 +17,33 @@
  */
 package pcgen.base.formula.operator.generic;
 
-import java.lang.reflect.Array;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-public class GenericEqualsTest extends TestCase
+import org.junit.jupiter.api.Test;
+
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.testsupport.TestUtilities;
+
+public class GenericEqualsTest
 {
-
-	private static final Class<Number> NUMBER_CLASS = Number.class;
-	private static final Class<Boolean> BOOLEAN_CLASS = Boolean.class;
-	private static final Class<Integer> INTEGER_CLASS = Integer.class;
-	private static final Class<Number[]> NUMBER_ARRAY_CLASS =
-			(Class<Number[]>) Array.newInstance(NUMBER_CLASS, 0).getClass();
-
-	private final GenericEquals op = new GenericEquals();
-
+	@Test
 	public void testOperator()
 	{
+		GenericEquals op = new GenericEquals();
 		assertNotNull(op.getOperator());
 		assertTrue(op.getOperator().getSymbol().equals("=="));
 	}
 
+	@Test
 	public void testAbstractEvaluateNulls()
 	{
+		GenericEquals op = new GenericEquals();
 		try
 		{
 			assertNull(op.abstractEvaluate(null, null, null));
@@ -50,7 +54,7 @@ public class GenericEqualsTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(BOOLEAN_CLASS, null, null));
+			assertNull(op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, null, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -58,7 +62,7 @@ public class GenericEqualsTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(null, BOOLEAN_CLASS, null));
+			assertNull(op.abstractEvaluate(null, FormatUtilities.BOOLEAN_CLASS, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -66,55 +70,39 @@ public class GenericEqualsTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testAbstractEvaluateMismatch()
 	{
-		assertTrue(op.abstractEvaluate(BOOLEAN_CLASS, INTEGER_CLASS, null).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_CLASS, BOOLEAN_CLASS, null).isEmpty());
+		GenericEquals op = new GenericEquals();
+		assertTrue(op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, TestUtilities.INTEGER_CLASS, null).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.BOOLEAN_CLASS, null).isEmpty());
 		//Don't handle arrays
-		assertTrue(op.abstractEvaluate(NUMBER_ARRAY_CLASS, NUMBER_ARRAY_CLASS, null).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_CLASS, NUMBER_ARRAY_CLASS, null).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_ARRAY_CLASS, NUMBER_CLASS, null).isEmpty());
+		assertTrue(op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, TestUtilities.NUMBER_ARRAY_CLASS, null).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, TestUtilities.NUMBER_ARRAY_CLASS, null).isEmpty());
+		assertTrue(op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, FormatUtilities.NUMBER_CLASS, null).isEmpty());
 	}
 
+	@Test
 	public void testAbstractEvaluateLegal()
 	{
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(BOOLEAN_CLASS, BOOLEAN_CLASS, null).get().getManagedClass());
+		GenericEquals op = new GenericEquals();
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, FormatUtilities.BOOLEAN_CLASS, null).get().getManagedClass());
 	}
 
+	@Test
 	public void testEvaluateFailNull()
 	{
-		try
-		{
-			assertNull(op.evaluate(null, null));
-			fail();
-		}
-		catch (NullPointerException | IllegalArgumentException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(Boolean.TRUE, null));
-			fail();
-		}
-		catch (NullPointerException | IllegalArgumentException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(null, Boolean.FALSE));
-			fail();
-		}
-		catch (NullPointerException | IllegalArgumentException e)
-		{
-			//expected
-		}
+		GenericEquals op = new GenericEquals();
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(Boolean.TRUE, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, Boolean.FALSE));
 	}
 
+	@Test
 	public void testEvaluateMismatch()
 	{
+		GenericEquals op = new GenericEquals();
 		try
 		{
 			Object result = op.evaluate(Boolean.TRUE, Double.valueOf(4.5));
@@ -141,8 +129,10 @@ public class GenericEqualsTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testEvaluateLegal()
 	{
+		GenericEquals op = new GenericEquals();
 		assertEquals(Boolean.TRUE, op.evaluate(Boolean.TRUE, Boolean.TRUE));
 		assertEquals(Boolean.FALSE, op.evaluate(Boolean.FALSE, Boolean.TRUE));
 		assertEquals(Boolean.FALSE, op.evaluate(Boolean.TRUE, Boolean.FALSE));

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/operator/generic/GenericNotEqualTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/operator/generic/GenericNotEqualTest.java
@@ -17,29 +17,33 @@
  */
 package pcgen.base.formula.operator.generic;
 
-import java.lang.reflect.Array;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-public class GenericNotEqualTest extends TestCase
+import org.junit.jupiter.api.Test;
+
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.testsupport.TestUtilities;
+
+public class GenericNotEqualTest
 {
-
-	private static final Class<Number> NUMBER_CLASS = Number.class;
-	private static final Class<Boolean> BOOLEAN_CLASS = Boolean.class;
-	private static final Class<Integer> INTEGER_CLASS = Integer.class;
-	private static final Class<Number[]> NUMBER_ARRAY_CLASS =
-			(Class<Number[]>) Array.newInstance(NUMBER_CLASS, 0).getClass();
-
-	private final GenericNotEqual op = new GenericNotEqual();
-
+	@Test
 	public void testOperator()
 	{
+		GenericNotEqual op = new GenericNotEqual();
 		assertNotNull(op.getOperator());
 		assertTrue(op.getOperator().getSymbol().equals("!="));
 	}
 
+	@Test
 	public void testAbstractEvaluateNulls()
 	{
+		GenericNotEqual op = new GenericNotEqual();
 		try
 		{
 			assertNull(op.abstractEvaluate(null, null, null));
@@ -50,7 +54,7 @@ public class GenericNotEqualTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(BOOLEAN_CLASS, null, null));
+			assertNull(op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, null, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -58,7 +62,7 @@ public class GenericNotEqualTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(null, BOOLEAN_CLASS, null));
+			assertNull(op.abstractEvaluate(null, FormatUtilities.BOOLEAN_CLASS, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -66,55 +70,39 @@ public class GenericNotEqualTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testAbstractEvaluateMismatch()
 	{
-		assertTrue(op.abstractEvaluate(BOOLEAN_CLASS, INTEGER_CLASS, null).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_CLASS, BOOLEAN_CLASS, null).isEmpty());
+		GenericNotEqual op = new GenericNotEqual();
+		assertTrue(op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, TestUtilities.INTEGER_CLASS, null).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.BOOLEAN_CLASS, null).isEmpty());
 		//Don't handle arrays
-		assertTrue(op.abstractEvaluate(NUMBER_ARRAY_CLASS, NUMBER_ARRAY_CLASS, null).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_CLASS, NUMBER_ARRAY_CLASS, null).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_ARRAY_CLASS, NUMBER_CLASS, null).isEmpty());
+		assertTrue(op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, TestUtilities.NUMBER_ARRAY_CLASS, null).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, TestUtilities.NUMBER_ARRAY_CLASS, null).isEmpty());
+		assertTrue(op.abstractEvaluate(TestUtilities.NUMBER_ARRAY_CLASS, FormatUtilities.NUMBER_CLASS, null).isEmpty());
 	}
 
+	@Test
 	public void testAbstractEvaluateLegal()
 	{
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(BOOLEAN_CLASS, BOOLEAN_CLASS, null).get().getManagedClass());
+		GenericNotEqual op = new GenericNotEqual();
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, FormatUtilities.BOOLEAN_CLASS, null).get().getManagedClass());
 	}
 
+	@Test
 	public void testEvaluateFailNull()
 	{
-		try
-		{
-			assertNull(op.evaluate(null, null));
-			fail();
-		}
-		catch (NullPointerException | IllegalArgumentException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(Boolean.TRUE, null));
-			fail();
-		}
-		catch (NullPointerException | IllegalArgumentException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(null, Boolean.FALSE));
-			fail();
-		}
-		catch (NullPointerException | IllegalArgumentException e)
-		{
-			//expected
-		}
+		GenericNotEqual op = new GenericNotEqual();
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(Boolean.TRUE, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, Boolean.FALSE));
 	}
 
+	@Test
 	public void testEvaluateMismatch()
 	{
+		GenericNotEqual op = new GenericNotEqual();
 		try
 		{
 			Object result = op.evaluate(Boolean.TRUE, Double.valueOf(4.5));
@@ -141,8 +129,10 @@ public class GenericNotEqualTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testEvaluateLegal()
 	{
+		GenericNotEqual op = new GenericNotEqual();
 		assertEquals(Boolean.FALSE, op.evaluate(Boolean.TRUE, Boolean.TRUE));
 		assertEquals(Boolean.TRUE, op.evaluate(Boolean.FALSE, Boolean.TRUE));
 		assertEquals(Boolean.TRUE, op.evaluate(Boolean.TRUE, Boolean.FALSE));

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/operator/number/NumberAddTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/operator/number/NumberAddTest.java
@@ -17,26 +17,32 @@
  */
 package pcgen.base.formula.operator.number;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class NumberAddTest extends TestCase
+import org.junit.jupiter.api.Test;
+
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.testsupport.TestUtilities;
+
+public class NumberAddTest
 {
 
-	private static final Class<Number> NUMBER_CLASS = Number.class;
-	private static final Class<Boolean> BOOLEAN_CLASS = Boolean.class;
-	private static final Class<Integer> INTEGER_CLASS = Integer.class;
-	private static final Class<Double> DOUBLE_CLASS = Double.class;
-
-	private final NumberAdd op = new NumberAdd();
-
+	@Test
 	public void testOperator()
 	{
+		NumberAdd op = new NumberAdd();
 		assertNotNull(op.getOperator());
 		assertTrue(op.getOperator().getSymbol().equals("+"));
 	}
 
+	@Test
 	public void testAbstractEvaluateNulls()
 	{
+		NumberAdd op = new NumberAdd();
 		try
 		{
 			assertNull(op.abstractEvaluate(null, null, null));
@@ -47,7 +53,7 @@ public class NumberAddTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(NUMBER_CLASS, null, null));
+			assertNull(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, null, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -55,7 +61,7 @@ public class NumberAddTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(null, NUMBER_CLASS, null));
+			assertNull(op.abstractEvaluate(null, FormatUtilities.NUMBER_CLASS, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -63,84 +69,54 @@ public class NumberAddTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testAbstractEvaluateMismatch()
 	{
-		assertTrue(op.abstractEvaluate(BOOLEAN_CLASS, INTEGER_CLASS, null).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_CLASS, BOOLEAN_CLASS, null).isEmpty());
+		NumberAdd op = new NumberAdd();
+		assertTrue(op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, TestUtilities.INTEGER_CLASS, null).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.BOOLEAN_CLASS, null).isEmpty());
 	}
 
+	@Test
 	public void testAbstractEvaluateLegal()
 	{
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(NUMBER_CLASS, NUMBER_CLASS, null).get().getManagedClass());
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(DOUBLE_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(INTEGER_CLASS, INTEGER_CLASS, null).get().getManagedClass());
+		NumberAdd op = new NumberAdd();
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.NUMBER_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(TestUtilities.DOUBLE_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(TestUtilities.INTEGER_CLASS, TestUtilities.INTEGER_CLASS, null).get().getManagedClass());
 		//mixed okay too
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(NUMBER_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(INTEGER_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(DOUBLE_CLASS, INTEGER_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(TestUtilities.INTEGER_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(TestUtilities.DOUBLE_CLASS, TestUtilities.INTEGER_CLASS, null).get().getManagedClass());
 	}
 
+	@Test
 	public void testEvaluateFailNull()
 	{
-		try
-		{
-			assertNull(op.evaluate(null, null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(Integer.valueOf(0), null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(null, Double.valueOf(4.5)));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
+		NumberAdd op = new NumberAdd();
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(Integer.valueOf(0), null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, Double.valueOf(4.5)));
 	}
 
+	@Test
 	public void testEvaluateMismatch()
 	{
-		try
-		{
-			assertNull(op.evaluate(true, Double.valueOf(4.5)));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(new Object(), Double.valueOf(4.5)));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
+		NumberAdd op = new NumberAdd();
+		assertThrows(ClassCastException.class, () -> op.evaluate(true, Double.valueOf(4.5)));
+		assertThrows(ClassCastException.class, () -> op.evaluate(new Object(), Double.valueOf(4.5)));
 	}
 
+	@Test
 	public void testEvaluateLegal()
 	{
+		NumberAdd op = new NumberAdd();
 		assertEquals(Double.valueOf(3.3),
 			op.evaluate(Integer.valueOf(2), Double.valueOf(1.3)));
 		assertEquals(Integer.valueOf(6),

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/operator/number/NumberDivideTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/operator/number/NumberDivideTest.java
@@ -17,26 +17,32 @@
  */
 package pcgen.base.formula.operator.number;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class NumberDivideTest extends TestCase
+import org.junit.jupiter.api.Test;
+
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.testsupport.TestUtilities;
+
+public class NumberDivideTest
 {
 
-	private static final Class<Number> NUMBER_CLASS = Number.class;
-	private static final Class<Boolean> BOOLEAN_CLASS = Boolean.class;
-	private static final Class<Integer> INTEGER_CLASS = Integer.class;
-	private static final Class<Double> DOUBLE_CLASS = Double.class;
-
-	private final NumberDivide op = new NumberDivide();
-
+	@Test
 	public void testOperator()
 	{
+		NumberDivide op = new NumberDivide();
 		assertNotNull(op.getOperator());
 		assertTrue(op.getOperator().getSymbol().equals("/"));
 	}
 
+	@Test
 	public void testAbstractEvaluateNulls()
 	{
+		NumberDivide op = new NumberDivide();
 		try
 		{
 			assertNull(op.abstractEvaluate(null, null, null));
@@ -47,7 +53,7 @@ public class NumberDivideTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(NUMBER_CLASS, null, null));
+			assertNull(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, null, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -55,7 +61,7 @@ public class NumberDivideTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(null, NUMBER_CLASS, null));
+			assertNull(op.abstractEvaluate(null, FormatUtilities.NUMBER_CLASS, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -63,84 +69,54 @@ public class NumberDivideTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testAbstractEvaluateMismatch()
 	{
-		assertTrue(op.abstractEvaluate(BOOLEAN_CLASS, INTEGER_CLASS, null).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_CLASS, BOOLEAN_CLASS, null).isEmpty());
+		NumberDivide op = new NumberDivide();
+		assertTrue(op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, TestUtilities.INTEGER_CLASS, null).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.BOOLEAN_CLASS, null).isEmpty());
 	}
 
+	@Test
 	public void testAbstractEvaluateLegal()
 	{
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(NUMBER_CLASS, NUMBER_CLASS, null).get().getManagedClass());
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(DOUBLE_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(INTEGER_CLASS, INTEGER_CLASS, null).get().getManagedClass());
+		NumberDivide op = new NumberDivide();
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.NUMBER_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(TestUtilities.DOUBLE_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(TestUtilities.INTEGER_CLASS, TestUtilities.INTEGER_CLASS, null).get().getManagedClass());
 		//mixed okay too
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(NUMBER_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(INTEGER_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(DOUBLE_CLASS, INTEGER_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(TestUtilities.INTEGER_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(TestUtilities.DOUBLE_CLASS, TestUtilities.INTEGER_CLASS, null).get().getManagedClass());
 	}
 
+	@Test
 	public void testEvaluateFailNull()
 	{
-		try
-		{
-			assertNull(op.evaluate(null, null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(Integer.valueOf(0), null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(null, Double.valueOf(4.5)));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
+		NumberDivide op = new NumberDivide();
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(Integer.valueOf(0), null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, Double.valueOf(4.5)));
 	}
 
+	@Test
 	public void testEvaluateMismatch()
 	{
-		try
-		{
-			assertNull(op.evaluate(true, Double.valueOf(4.5)));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(new Object(), Double.valueOf(4.5)));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
+		NumberDivide op = new NumberDivide();
+		assertThrows(ClassCastException.class, () -> op.evaluate(true, Double.valueOf(4.5)));
+		assertThrows(ClassCastException.class, () -> op.evaluate(new Object(), Double.valueOf(4.5)));
 	}
 
+	@Test
 	public void testEvaluateLegal()
 	{
+		NumberDivide op = new NumberDivide();
 		assertEquals(Double.valueOf(2/1.3),
 			op.evaluate(Integer.valueOf(2), Double.valueOf(1.3)));
 		assertEquals(Integer.valueOf(2),

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/operator/number/NumberEqualsTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/operator/number/NumberEqualsTest.java
@@ -17,26 +17,32 @@
  */
 package pcgen.base.formula.operator.number;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class NumberEqualsTest extends TestCase
+import org.junit.jupiter.api.Test;
+
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.testsupport.TestUtilities;
+
+public class NumberEqualsTest
 {
 
-	private static final Class<Number> NUMBER_CLASS = Number.class;
-	private static final Class<Boolean> BOOLEAN_CLASS = Boolean.class;
-	private static final Class<Integer> INTEGER_CLASS = Integer.class;
-	private static final Class<Double> DOUBLE_CLASS = Double.class;
-
-	private final NumberEquals op = new NumberEquals();
-
+	@Test
 	public void testOperator()
 	{
+		NumberEquals op = new NumberEquals();
 		assertNotNull(op.getOperator());
 		assertTrue(op.getOperator().getSymbol().equals("=="));
 	}
 
+	@Test
 	public void testAbstractEvaluateNulls()
 	{
+		NumberEquals op = new NumberEquals();
 		try
 		{
 			assertNull(op.abstractEvaluate(null, null, null));
@@ -47,7 +53,7 @@ public class NumberEqualsTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(NUMBER_CLASS, null, null));
+			assertNull(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, null, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -55,7 +61,7 @@ public class NumberEqualsTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(null, NUMBER_CLASS, null));
+			assertNull(op.abstractEvaluate(null, FormatUtilities.NUMBER_CLASS, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -63,84 +69,54 @@ public class NumberEqualsTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testAbstractEvaluateMismatch()
 	{
-		assertTrue(op.abstractEvaluate(BOOLEAN_CLASS, INTEGER_CLASS, null).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_CLASS, BOOLEAN_CLASS, null).isEmpty());
+		NumberEquals op = new NumberEquals();
+		assertTrue(op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, TestUtilities.INTEGER_CLASS, null).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.BOOLEAN_CLASS, null).isEmpty());
 	}
 
+	@Test
 	public void testAbstractEvaluateLegal()
 	{
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(NUMBER_CLASS, NUMBER_CLASS, null).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(DOUBLE_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(INTEGER_CLASS, INTEGER_CLASS, null).get().getManagedClass());
+		NumberEquals op = new NumberEquals();
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.NUMBER_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.DOUBLE_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.INTEGER_CLASS, TestUtilities.INTEGER_CLASS, null).get().getManagedClass());
 		//mixed okay too
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(NUMBER_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(INTEGER_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(DOUBLE_CLASS, INTEGER_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.INTEGER_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.DOUBLE_CLASS, TestUtilities.INTEGER_CLASS, null).get().getManagedClass());
 	}
 
+	@Test
 	public void testEvaluateFailNull()
 	{
-		try
-		{
-			assertNull(op.evaluate(null, null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(Integer.valueOf(0), null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(null, Double.valueOf(4.5)));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
+		NumberEquals op = new NumberEquals();
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(Integer.valueOf(0), null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, Double.valueOf(4.5)));
 	}
 
+	@Test
 	public void testEvaluateMismatch()
 	{
-		try
-		{
-			assertNull(op.evaluate(true, Double.valueOf(4.5)));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(new Object(), Double.valueOf(4.5)));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
+		NumberEquals op = new NumberEquals();
+		assertThrows(ClassCastException.class, () -> op.evaluate(true, Double.valueOf(4.5)));
+		assertThrows(ClassCastException.class, () -> op.evaluate(new Object(), Double.valueOf(4.5)));
 	}
 
+	@Test
 	public void testEvaluateLegal()
 	{
+		NumberEquals op = new NumberEquals();
 		assertEquals(Boolean.FALSE,
 			op.evaluate(Integer.valueOf(2), Double.valueOf(1.3)));
 		assertEquals(Boolean.FALSE,

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/operator/number/NumberGreaterThanOrEqualToTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/operator/number/NumberGreaterThanOrEqualToTest.java
@@ -17,26 +17,31 @@
  */
 package pcgen.base.formula.operator.number;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class NumberGreaterThanOrEqualToTest extends TestCase
+import org.junit.jupiter.api.Test;
+
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.testsupport.TestUtilities;
+
+public class NumberGreaterThanOrEqualToTest
 {
-
-	private static final Class<Number> NUMBER_CLASS = Number.class;
-	private static final Class<Boolean> BOOLEAN_CLASS = Boolean.class;
-	private static final Class<Integer> INTEGER_CLASS = Integer.class;
-	private static final Class<Double> DOUBLE_CLASS = Double.class;
-
-	private final NumberGreaterThanOrEqualTo op = new NumberGreaterThanOrEqualTo();
-
+	@Test
 	public void testOperator()
 	{
+		NumberGreaterThanOrEqualTo op = new NumberGreaterThanOrEqualTo();
 		assertNotNull(op.getOperator());
 		assertTrue(op.getOperator().getSymbol().equals(">="));
 	}
 
+	@Test
 	public void testAbstractEvaluateNulls()
 	{
+		NumberGreaterThanOrEqualTo op = new NumberGreaterThanOrEqualTo();
 		try
 		{
 			assertNull(op.abstractEvaluate(null, null, null));
@@ -47,7 +52,7 @@ public class NumberGreaterThanOrEqualToTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(NUMBER_CLASS, null, null));
+			assertNull(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, null, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -55,7 +60,7 @@ public class NumberGreaterThanOrEqualToTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(null, NUMBER_CLASS, null));
+			assertNull(op.abstractEvaluate(null, FormatUtilities.NUMBER_CLASS, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -63,84 +68,54 @@ public class NumberGreaterThanOrEqualToTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testAbstractEvaluateMismatch()
 	{
-		assertTrue(op.abstractEvaluate(BOOLEAN_CLASS, INTEGER_CLASS, null).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_CLASS, BOOLEAN_CLASS, null).isEmpty());
+		NumberGreaterThanOrEqualTo op = new NumberGreaterThanOrEqualTo();
+		assertTrue(op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, TestUtilities.INTEGER_CLASS, null).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.BOOLEAN_CLASS, null).isEmpty());
 	}
 
+	@Test
 	public void testAbstractEvaluateLegal()
 	{
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(NUMBER_CLASS, NUMBER_CLASS, null).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(DOUBLE_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(INTEGER_CLASS, INTEGER_CLASS, null).get().getManagedClass());
+		NumberGreaterThanOrEqualTo op = new NumberGreaterThanOrEqualTo();
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.NUMBER_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.DOUBLE_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.INTEGER_CLASS, TestUtilities.INTEGER_CLASS, null).get().getManagedClass());
 		//mixed okay too
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(NUMBER_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(INTEGER_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(DOUBLE_CLASS, INTEGER_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.INTEGER_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.DOUBLE_CLASS, TestUtilities.INTEGER_CLASS, null).get().getManagedClass());
 	}
 
+	@Test
 	public void testEvaluateFailNull()
 	{
-		try
-		{
-			assertNull(op.evaluate(null, null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(Integer.valueOf(0), null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(null, Double.valueOf(4.5)));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
+		NumberGreaterThanOrEqualTo op = new NumberGreaterThanOrEqualTo();
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(Integer.valueOf(0), null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, Double.valueOf(4.5)));
 	}
 
+	@Test
 	public void testEvaluateMismatch()
 	{
-		try
-		{
-			assertNull(op.evaluate(true, Double.valueOf(4.5)));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(new Object(), Double.valueOf(4.5)));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
+		NumberGreaterThanOrEqualTo op = new NumberGreaterThanOrEqualTo();
+		assertThrows(ClassCastException.class, () -> op.evaluate(true, Double.valueOf(4.5)));
+		assertThrows(ClassCastException.class, () -> op.evaluate(new Object(), Double.valueOf(4.5)));
 	}
 
+	@Test
 	public void testEvaluateLegal()
 	{
+		NumberGreaterThanOrEqualTo op = new NumberGreaterThanOrEqualTo();
 		assertEquals(Boolean.TRUE,
 			op.evaluate(Integer.valueOf(2), Double.valueOf(1.3)));
 		assertEquals(Boolean.TRUE,

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/operator/number/NumberGreaterThanTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/operator/number/NumberGreaterThanTest.java
@@ -17,26 +17,31 @@
  */
 package pcgen.base.formula.operator.number;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class NumberGreaterThanTest extends TestCase
+import org.junit.jupiter.api.Test;
+
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.testsupport.TestUtilities;
+
+public class NumberGreaterThanTest
 {
-
-	private static final Class<Number> NUMBER_CLASS = Number.class;
-	private static final Class<Boolean> BOOLEAN_CLASS = Boolean.class;
-	private static final Class<Integer> INTEGER_CLASS = Integer.class;
-	private static final Class<Double> DOUBLE_CLASS = Double.class;
-
-	private final NumberGreaterThan op = new NumberGreaterThan();
-
+	@Test
 	public void testOperator()
 	{
+		NumberGreaterThan op = new NumberGreaterThan();
 		assertNotNull(op.getOperator());
 		assertTrue(op.getOperator().getSymbol().equals(">"));
 	}
 
+	@Test
 	public void testAbstractEvaluateNulls()
 	{
+		NumberGreaterThan op = new NumberGreaterThan();
 		try
 		{
 			assertNull(op.abstractEvaluate(null, null, null));
@@ -47,7 +52,7 @@ public class NumberGreaterThanTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(NUMBER_CLASS, null, null));
+			assertNull(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, null, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -55,7 +60,7 @@ public class NumberGreaterThanTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(null, NUMBER_CLASS, null));
+			assertNull(op.abstractEvaluate(null, FormatUtilities.NUMBER_CLASS, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -63,84 +68,54 @@ public class NumberGreaterThanTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testAbstractEvaluateMismatch()
 	{
-		assertTrue(op.abstractEvaluate(BOOLEAN_CLASS, INTEGER_CLASS, null).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_CLASS, BOOLEAN_CLASS, null).isEmpty());
+		NumberGreaterThan op = new NumberGreaterThan();
+		assertTrue(op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, TestUtilities.INTEGER_CLASS, null).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.BOOLEAN_CLASS, null).isEmpty());
 	}
 
+	@Test
 	public void testAbstractEvaluateLegal()
 	{
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(NUMBER_CLASS, NUMBER_CLASS, null).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(DOUBLE_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(INTEGER_CLASS, INTEGER_CLASS, null).get().getManagedClass());
+		NumberGreaterThan op = new NumberGreaterThan();
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.NUMBER_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.DOUBLE_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.INTEGER_CLASS, TestUtilities.INTEGER_CLASS, null).get().getManagedClass());
 		//mixed okay too
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(NUMBER_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(INTEGER_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(DOUBLE_CLASS, INTEGER_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.INTEGER_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.DOUBLE_CLASS, TestUtilities.INTEGER_CLASS, null).get().getManagedClass());
 	}
 
+	@Test
 	public void testEvaluateFailNull()
 	{
-		try
-		{
-			assertNull(op.evaluate(null, null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(Integer.valueOf(0), null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(null, Double.valueOf(4.5)));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
+		NumberGreaterThan op = new NumberGreaterThan();
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(Integer.valueOf(0), null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, Double.valueOf(4.5)));
 	}
 
+	@Test
 	public void testEvaluateMismatch()
 	{
-		try
-		{
-			assertNull(op.evaluate(true, Double.valueOf(4.5)));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(new Object(), Double.valueOf(4.5)));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
+		NumberGreaterThan op = new NumberGreaterThan();
+		assertThrows(ClassCastException.class, () -> op.evaluate(true, Double.valueOf(4.5)));
+		assertThrows(ClassCastException.class, () -> op.evaluate(new Object(), Double.valueOf(4.5)));
 	}
 
+	@Test
 	public void testEvaluateLegal()
 	{
+		NumberGreaterThan op = new NumberGreaterThan();
 		assertEquals(Boolean.TRUE,
 			op.evaluate(Integer.valueOf(2), Double.valueOf(1.3)));
 		assertEquals(Boolean.TRUE,

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/operator/number/NumberLessThanOrEqualToTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/operator/number/NumberLessThanOrEqualToTest.java
@@ -17,26 +17,31 @@
  */
 package pcgen.base.formula.operator.number;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class NumberLessThanOrEqualToTest extends TestCase
+import org.junit.jupiter.api.Test;
+
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.testsupport.TestUtilities;
+
+public class NumberLessThanOrEqualToTest
 {
-
-	private static final Class<Number> NUMBER_CLASS = Number.class;
-	private static final Class<Boolean> BOOLEAN_CLASS = Boolean.class;
-	private static final Class<Integer> INTEGER_CLASS = Integer.class;
-	private static final Class<Double> DOUBLE_CLASS = Double.class;
-
-	private final NumberLessThanOrEqualTo op = new NumberLessThanOrEqualTo();
-
+	@Test
 	public void testOperator()
 	{
+		NumberLessThanOrEqualTo op = new NumberLessThanOrEqualTo();
 		assertNotNull(op.getOperator());
 		assertTrue(op.getOperator().getSymbol().equals("<="));
 	}
 
+	@Test
 	public void testAbstractEvaluateNulls()
 	{
+		NumberLessThanOrEqualTo op = new NumberLessThanOrEqualTo();
 		try
 		{
 			assertNull(op.abstractEvaluate(null, null, null));
@@ -47,7 +52,7 @@ public class NumberLessThanOrEqualToTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(NUMBER_CLASS, null, null));
+			assertNull(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, null, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -55,7 +60,7 @@ public class NumberLessThanOrEqualToTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(null, NUMBER_CLASS, null));
+			assertNull(op.abstractEvaluate(null, FormatUtilities.NUMBER_CLASS, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -63,84 +68,54 @@ public class NumberLessThanOrEqualToTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testAbstractEvaluateMismatch()
 	{
-		assertTrue(op.abstractEvaluate(BOOLEAN_CLASS, INTEGER_CLASS, null).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_CLASS, BOOLEAN_CLASS, null).isEmpty());
+		NumberLessThanOrEqualTo op = new NumberLessThanOrEqualTo();
+		assertTrue(op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, TestUtilities.INTEGER_CLASS, null).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.BOOLEAN_CLASS, null).isEmpty());
 	}
 
+	@Test
 	public void testAbstractEvaluateLegal()
 	{
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(NUMBER_CLASS, NUMBER_CLASS, null).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(DOUBLE_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(INTEGER_CLASS, INTEGER_CLASS, null).get().getManagedClass());
+		NumberLessThanOrEqualTo op = new NumberLessThanOrEqualTo();
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.NUMBER_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.DOUBLE_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.INTEGER_CLASS, TestUtilities.INTEGER_CLASS, null).get().getManagedClass());
 		//mixed okay too
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(NUMBER_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(INTEGER_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(DOUBLE_CLASS, INTEGER_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.INTEGER_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.DOUBLE_CLASS, TestUtilities.INTEGER_CLASS, null).get().getManagedClass());
 	}
 
+	@Test
 	public void testEvaluateFailNull()
 	{
-		try
-		{
-			assertNull(op.evaluate(null, null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(Integer.valueOf(0), null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(null, Double.valueOf(4.5)));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
+		NumberLessThanOrEqualTo op = new NumberLessThanOrEqualTo();
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(Integer.valueOf(0), null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, Double.valueOf(4.5)));
 	}
 
+	@Test
 	public void testEvaluateMismatch()
 	{
-		try
-		{
-			assertNull(op.evaluate(true, Double.valueOf(4.5)));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(new Object(), Double.valueOf(4.5)));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
+		NumberLessThanOrEqualTo op = new NumberLessThanOrEqualTo();
+		assertThrows(ClassCastException.class, () -> op.evaluate(true, Double.valueOf(4.5)));
+		assertThrows(ClassCastException.class, () -> op.evaluate(new Object(), Double.valueOf(4.5)));
 	}
 
+	@Test
 	public void testEvaluateLegal()
 	{
+		NumberLessThanOrEqualTo op = new NumberLessThanOrEqualTo();
 		assertEquals(Boolean.FALSE,
 			op.evaluate(Integer.valueOf(2), Double.valueOf(1.3)));
 		assertEquals(Boolean.FALSE,

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/operator/number/NumberLessThanTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/operator/number/NumberLessThanTest.java
@@ -17,26 +17,31 @@
  */
 package pcgen.base.formula.operator.number;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class NumberLessThanTest extends TestCase
+import org.junit.jupiter.api.Test;
+
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.testsupport.TestUtilities;
+
+public class NumberLessThanTest
 {
-
-	private static final Class<Number> NUMBER_CLASS = Number.class;
-	private static final Class<Boolean> BOOLEAN_CLASS = Boolean.class;
-	private static final Class<Integer> INTEGER_CLASS = Integer.class;
-	private static final Class<Double> DOUBLE_CLASS = Double.class;
-
-	private final NumberLessThan op = new NumberLessThan();
-
+	@Test
 	public void testOperator()
 	{
+		NumberLessThan op = new NumberLessThan();
 		assertNotNull(op.getOperator());
 		assertTrue(op.getOperator().getSymbol().equals("<"));
 	}
 
+	@Test
 	public void testAbstractEvaluateNulls()
 	{
+		NumberLessThan op = new NumberLessThan();
 		try
 		{
 			assertNull(op.abstractEvaluate(null, null, null));
@@ -47,7 +52,7 @@ public class NumberLessThanTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(NUMBER_CLASS, null, null));
+			assertNull(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, null, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -55,7 +60,7 @@ public class NumberLessThanTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(null, NUMBER_CLASS, null));
+			assertNull(op.abstractEvaluate(null, FormatUtilities.NUMBER_CLASS, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -63,84 +68,54 @@ public class NumberLessThanTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testAbstractEvaluateMismatch()
 	{
-		assertTrue(op.abstractEvaluate(BOOLEAN_CLASS, INTEGER_CLASS, null).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_CLASS, BOOLEAN_CLASS, null).isEmpty());
+		NumberLessThan op = new NumberLessThan();
+		assertTrue(op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, TestUtilities.INTEGER_CLASS, null).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.BOOLEAN_CLASS, null).isEmpty());
 	}
 
+	@Test
 	public void testAbstractEvaluateLegal()
 	{
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(NUMBER_CLASS, NUMBER_CLASS, null).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(DOUBLE_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(INTEGER_CLASS, INTEGER_CLASS, null).get().getManagedClass());
+		NumberLessThan op = new NumberLessThan();
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.NUMBER_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.DOUBLE_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.INTEGER_CLASS, TestUtilities.INTEGER_CLASS, null).get().getManagedClass());
 		//mixed okay too
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(NUMBER_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(INTEGER_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(DOUBLE_CLASS, INTEGER_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.INTEGER_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.DOUBLE_CLASS, TestUtilities.INTEGER_CLASS, null).get().getManagedClass());
 	}
 
+	@Test
 	public void testEvaluateFailNull()
 	{
-		try
-		{
-			assertNull(op.evaluate(null, null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(Integer.valueOf(0), null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(null, Double.valueOf(4.5)));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
+		NumberLessThan op = new NumberLessThan();
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(Integer.valueOf(0), null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, Double.valueOf(4.5)));
 	}
 
+	@Test
 	public void testEvaluateMismatch()
 	{
-		try
-		{
-			assertNull(op.evaluate(true, Double.valueOf(4.5)));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(new Object(), Double.valueOf(4.5)));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
+		NumberLessThan op = new NumberLessThan();
+		assertThrows(ClassCastException.class, () -> op.evaluate(true, Double.valueOf(4.5)));
+		assertThrows(ClassCastException.class, () -> op.evaluate(new Object(), Double.valueOf(4.5)));
 	}
 
+	@Test
 	public void testEvaluateLegal()
 	{
+		NumberLessThan op = new NumberLessThan();
 		assertEquals(Boolean.FALSE,
 			op.evaluate(Integer.valueOf(2), Double.valueOf(1.3)));
 		assertEquals(Boolean.FALSE,

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/operator/number/NumberMinusTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/operator/number/NumberMinusTest.java
@@ -17,26 +17,31 @@
  */
 package pcgen.base.formula.operator.number;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class NumberMinusTest extends TestCase
+import org.junit.jupiter.api.Test;
+
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.testsupport.TestUtilities;
+
+public class NumberMinusTest
 {
-
-	private static final Class<Number> NUMBER_CLASS = Number.class;
-	private static final Class<Integer> INTEGER_CLASS = Integer.class;
-	private static final Class<Double> DOUBLE_CLASS = Double.class;
-	private static final Class<Float> FLOAT_CLASS = Float.class;
-
-	private final NumberMinus op = new NumberMinus();
-
+	@Test
 	public void testOperator()
 	{
+		NumberMinus op = new NumberMinus();
 		assertNotNull(op.getOperator());
 		assertTrue(op.getOperator().getSymbol().equals("-"));
 	}
 
+	@Test
 	public void testAbstractEvaluateNulls()
 	{
+		NumberMinus op = new NumberMinus();
 		try
 		{
 			assertNull(op.abstractEvaluate(null));
@@ -47,47 +52,41 @@ public class NumberMinusTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testAbstractEvaluateMismatch()
 	{
+		NumberMinus op = new NumberMinus();
 		assertTrue(op.abstractEvaluate(Boolean.class).isEmpty());
 	}
 
+	@Test
 	public void testAbstractEvaluateLegal()
 	{
-		assertEquals(NUMBER_CLASS, op.abstractEvaluate(NUMBER_CLASS).get().getManagedClass());
-		assertEquals(NUMBER_CLASS, op.abstractEvaluate(DOUBLE_CLASS).get().getManagedClass());
-		assertEquals(NUMBER_CLASS, op.abstractEvaluate(FLOAT_CLASS).get().getManagedClass());
-		assertEquals(NUMBER_CLASS, op.abstractEvaluate(INTEGER_CLASS).get().getManagedClass());
+		NumberMinus op = new NumberMinus();
+		assertEquals(FormatUtilities.NUMBER_CLASS, op.abstractEvaluate(FormatUtilities.NUMBER_CLASS).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS, op.abstractEvaluate(TestUtilities.DOUBLE_CLASS).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS, op.abstractEvaluate(TestUtilities.FLOAT_CLASS).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS, op.abstractEvaluate(TestUtilities.INTEGER_CLASS).get().getManagedClass());
 	}
 
+	@Test
 	public void testEvaluateFailNull()
 	{
-		try
-		{
-			assertNull(op.evaluate(null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
+		NumberMinus op = new NumberMinus();
+		assertThrows(NullPointerException.class, () -> op.evaluate(null));
 	}
 
+	@Test
 	public void testEvaluateMismatch()
 	{
-		try
-		{
-			assertNull(op.evaluate(true));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
+		NumberMinus op = new NumberMinus();
+		assertThrows(ClassCastException.class, () -> op.evaluate(true));
 	}
 
+	@Test
 	public void testEvaluateLegal()
 	{
+		NumberMinus op = new NumberMinus();
 		assertEquals(Integer.valueOf(-2), op.evaluate(Integer.valueOf(2)));
 		assertEquals(Double.valueOf(1.3), op.evaluate(Double.valueOf(-1.3)));
 		assertEquals(Double.valueOf(-1.3f), op.evaluate(Float.valueOf(1.3f)));

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/operator/number/NumberMultiplyTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/operator/number/NumberMultiplyTest.java
@@ -17,26 +17,32 @@
  */
 package pcgen.base.formula.operator.number;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class NumberMultiplyTest extends TestCase
+import org.junit.jupiter.api.Test;
+
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.testsupport.TestUtilities;
+
+public class NumberMultiplyTest
 {
 
-	private static final Class<Number> NUMBER_CLASS = Number.class;
-	private static final Class<Boolean> BOOLEAN_CLASS = Boolean.class;
-	private static final Class<Integer> INTEGER_CLASS = Integer.class;
-	private static final Class<Double> DOUBLE_CLASS = Double.class;
-
-	private final NumberMultiply op = new NumberMultiply();
-
+	@Test
 	public void testOperator()
 	{
+		NumberMultiply op = new NumberMultiply();
 		assertNotNull(op.getOperator());
 		assertTrue(op.getOperator().getSymbol().equals("*"));
 	}
 
+	@Test
 	public void testAbstractEvaluateNulls()
 	{
+		NumberMultiply op = new NumberMultiply();
 		try
 		{
 			assertNull(op.abstractEvaluate(null, null, null));
@@ -47,7 +53,7 @@ public class NumberMultiplyTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(NUMBER_CLASS, null, null));
+			assertNull(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, null, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -55,7 +61,7 @@ public class NumberMultiplyTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(null, NUMBER_CLASS, null));
+			assertNull(op.abstractEvaluate(null, FormatUtilities.NUMBER_CLASS, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -63,84 +69,54 @@ public class NumberMultiplyTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testAbstractEvaluateMismatch()
 	{
-		assertTrue(op.abstractEvaluate(BOOLEAN_CLASS, INTEGER_CLASS, null).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_CLASS, BOOLEAN_CLASS, null).isEmpty());
+		NumberMultiply op = new NumberMultiply();
+		assertTrue(op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, TestUtilities.INTEGER_CLASS, null).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.BOOLEAN_CLASS, null).isEmpty());
 	}
 
+	@Test
 	public void testAbstractEvaluateLegal()
 	{
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(NUMBER_CLASS, NUMBER_CLASS, null).get().getManagedClass());
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(DOUBLE_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(INTEGER_CLASS, INTEGER_CLASS, null).get().getManagedClass());
+		NumberMultiply op = new NumberMultiply();
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.NUMBER_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(TestUtilities.DOUBLE_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(TestUtilities.INTEGER_CLASS, TestUtilities.INTEGER_CLASS, null).get().getManagedClass());
 		//mixed okay too
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(NUMBER_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(INTEGER_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(DOUBLE_CLASS, INTEGER_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(TestUtilities.INTEGER_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(TestUtilities.DOUBLE_CLASS, TestUtilities.INTEGER_CLASS, null).get().getManagedClass());
 	}
 
+	@Test
 	public void testEvaluateFailNull()
 	{
-		try
-		{
-			assertNull(op.evaluate(null, null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(Integer.valueOf(0), null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(null, Double.valueOf(4.5)));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
+		NumberMultiply op = new NumberMultiply();
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(Integer.valueOf(0), null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, Double.valueOf(4.5)));
 	}
 
+	@Test
 	public void testEvaluateMismatch()
 	{
-		try
-		{
-			assertNull(op.evaluate(true, Double.valueOf(4.5)));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(new Object(), Double.valueOf(4.5)));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
+		NumberMultiply op = new NumberMultiply();
+		assertThrows(ClassCastException.class, () -> op.evaluate(true, Double.valueOf(4.5)));
+		assertThrows(ClassCastException.class, () -> op.evaluate(new Object(), Double.valueOf(4.5)));
 	}
 
+	@Test
 	public void testEvaluateLegal()
 	{
+		NumberMultiply op = new NumberMultiply();
 		assertEquals(Double.valueOf(2.6),
 			op.evaluate(Integer.valueOf(2), Double.valueOf(1.3)));
 		assertEquals(Integer.valueOf(8),

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/operator/number/NumberNotEqualTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/operator/number/NumberNotEqualTest.java
@@ -17,26 +17,32 @@
  */
 package pcgen.base.formula.operator.number;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class NumberNotEqualTest extends TestCase
+import org.junit.jupiter.api.Test;
+
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.testsupport.TestUtilities;
+
+public class NumberNotEqualTest
 {
 
-	private static final Class<Number> NUMBER_CLASS = Number.class;
-	private static final Class<Boolean> BOOLEAN_CLASS = Boolean.class;
-	private static final Class<Integer> INTEGER_CLASS = Integer.class;
-	private static final Class<Double> DOUBLE_CLASS = Double.class;
-
-	private final NumberNotEqual op = new NumberNotEqual();
-
+	@Test
 	public void testOperator()
 	{
+		NumberNotEqual op = new NumberNotEqual();
 		assertNotNull(op.getOperator());
 		assertTrue(op.getOperator().getSymbol().equals("!="));
 	}
 
+	@Test
 	public void testAbstractEvaluateNulls()
 	{
+		NumberNotEqual op = new NumberNotEqual();
 		try
 		{
 			assertNull(op.abstractEvaluate(null, null, null));
@@ -47,7 +53,7 @@ public class NumberNotEqualTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(NUMBER_CLASS, null, null));
+			assertNull(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, null, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -55,7 +61,7 @@ public class NumberNotEqualTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(null, NUMBER_CLASS, null));
+			assertNull(op.abstractEvaluate(null, FormatUtilities.NUMBER_CLASS, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -63,84 +69,54 @@ public class NumberNotEqualTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testAbstractEvaluateMismatch()
 	{
-		assertTrue(op.abstractEvaluate(BOOLEAN_CLASS, INTEGER_CLASS, null).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_CLASS, BOOLEAN_CLASS, null).isEmpty());
+		NumberNotEqual op = new NumberNotEqual();
+		assertTrue(op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, TestUtilities.INTEGER_CLASS, null).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.BOOLEAN_CLASS, null).isEmpty());
 	}
 
+	@Test
 	public void testAbstractEvaluateLegal()
 	{
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(NUMBER_CLASS, NUMBER_CLASS, null).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(DOUBLE_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(INTEGER_CLASS, INTEGER_CLASS, null).get().getManagedClass());
+		NumberNotEqual op = new NumberNotEqual();
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.NUMBER_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.DOUBLE_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.INTEGER_CLASS, TestUtilities.INTEGER_CLASS, null).get().getManagedClass());
 		//mixed okay too
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(NUMBER_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(INTEGER_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(BOOLEAN_CLASS,
-			op.abstractEvaluate(DOUBLE_CLASS, INTEGER_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.INTEGER_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.BOOLEAN_CLASS,
+			op.abstractEvaluate(TestUtilities.DOUBLE_CLASS, TestUtilities.INTEGER_CLASS, null).get().getManagedClass());
 	}
 
+	@Test
 	public void testEvaluateFailNull()
 	{
-		try
-		{
-			assertNull(op.evaluate(null, null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(Integer.valueOf(0), null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(null, Double.valueOf(4.5)));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
+		NumberNotEqual op = new NumberNotEqual();
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(Integer.valueOf(0), null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, Double.valueOf(4.5)));
 	}
 
+	@Test
 	public void testEvaluateMismatch()
 	{
-		try
-		{
-			assertNull(op.evaluate(true, Double.valueOf(4.5)));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(new Object(), Double.valueOf(4.5)));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
+		NumberNotEqual op = new NumberNotEqual();
+		assertThrows(ClassCastException.class, () -> op.evaluate(true, Double.valueOf(4.5)));
+		assertThrows(ClassCastException.class, () -> op.evaluate(new Object(), Double.valueOf(4.5)));
 	}
 
+	@Test
 	public void testEvaluateLegal()
 	{
+		NumberNotEqual op = new NumberNotEqual();
 		assertEquals(Boolean.TRUE,
 			op.evaluate(Integer.valueOf(2), Double.valueOf(1.3)));
 		assertEquals(Boolean.TRUE,

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/operator/number/NumberRemainderTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/operator/number/NumberRemainderTest.java
@@ -17,26 +17,32 @@
  */
 package pcgen.base.formula.operator.number;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class NumberRemainderTest extends TestCase
+import org.junit.jupiter.api.Test;
+
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.testsupport.TestUtilities;
+
+public class NumberRemainderTest
 {
 
-	private static final Class<Number> NUMBER_CLASS = Number.class;
-	private static final Class<Boolean> BOOLEAN_CLASS = Boolean.class;
-	private static final Class<Integer> INTEGER_CLASS = Integer.class;
-	private static final Class<Double> DOUBLE_CLASS = Double.class;
-
-	private final NumberRemainder op = new NumberRemainder();
-
+	@Test
 	public void testOperator()
 	{
+		NumberRemainder op = new NumberRemainder();
 		assertNotNull(op.getOperator());
 		assertTrue(op.getOperator().getSymbol().equals("%"));
 	}
 
+	@Test
 	public void testAbstractEvaluateNulls()
 	{
+		NumberRemainder op = new NumberRemainder();
 		try
 		{
 			assertNull(op.abstractEvaluate(null, null, null));
@@ -47,7 +53,7 @@ public class NumberRemainderTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(NUMBER_CLASS, null, null));
+			assertNull(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, null, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -55,7 +61,7 @@ public class NumberRemainderTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(null, NUMBER_CLASS, null));
+			assertNull(op.abstractEvaluate(null, FormatUtilities.NUMBER_CLASS, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -63,84 +69,54 @@ public class NumberRemainderTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testAbstractEvaluateMismatch()
 	{
-		assertTrue(op.abstractEvaluate(BOOLEAN_CLASS, INTEGER_CLASS, null).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_CLASS, BOOLEAN_CLASS, null).isEmpty());
+		NumberRemainder op = new NumberRemainder();
+		assertTrue(op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, TestUtilities.INTEGER_CLASS, null).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.BOOLEAN_CLASS, null).isEmpty());
 	}
 
+	@Test
 	public void testAbstractEvaluateLegal()
 	{
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(NUMBER_CLASS, NUMBER_CLASS, null).get().getManagedClass());
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(DOUBLE_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(INTEGER_CLASS, INTEGER_CLASS, null).get().getManagedClass());
+		NumberRemainder op = new NumberRemainder();
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.NUMBER_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(TestUtilities.DOUBLE_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(TestUtilities.INTEGER_CLASS, TestUtilities.INTEGER_CLASS, null).get().getManagedClass());
 		//mixed okay too
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(NUMBER_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(INTEGER_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(DOUBLE_CLASS, INTEGER_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(TestUtilities.INTEGER_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(TestUtilities.DOUBLE_CLASS, TestUtilities.INTEGER_CLASS, null).get().getManagedClass());
 	}
 
+	@Test
 	public void testEvaluateFailNull()
 	{
-		try
-		{
-			assertNull(op.evaluate(null, null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(Integer.valueOf(0), null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(null, Double.valueOf(4.5)));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
+		NumberRemainder op = new NumberRemainder();
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(Integer.valueOf(0), null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, Double.valueOf(4.5)));
 	}
 
+	@Test
 	public void testEvaluateMismatch()
 	{
-		try
-		{
-			assertNull(op.evaluate(true, Double.valueOf(4.5)));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(new Object(), Double.valueOf(4.5)));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
+		NumberRemainder op = new NumberRemainder();
+		assertThrows(ClassCastException.class, () -> op.evaluate(true, Double.valueOf(4.5)));
+		assertThrows(ClassCastException.class, () -> op.evaluate(new Object(), Double.valueOf(4.5)));
 	}
 
+	@Test
 	public void testEvaluateLegal()
 	{
+		NumberRemainder op = new NumberRemainder();
 		assertEquals(Double.valueOf(0.7),
 			op.evaluate(Integer.valueOf(2), Double.valueOf(1.3)));
 		assertEquals(Integer.valueOf(0),

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/operator/number/NumberSubtractTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/operator/number/NumberSubtractTest.java
@@ -17,26 +17,32 @@
  */
 package pcgen.base.formula.operator.number;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class NumberSubtractTest extends TestCase
+import org.junit.jupiter.api.Test;
+
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.testsupport.TestUtilities;
+
+public class NumberSubtractTest
 {
 
-	private static final Class<Number> NUMBER_CLASS = Number.class;
-	private static final Class<Boolean> BOOLEAN_CLASS = Boolean.class;
-	private static final Class<Integer> INTEGER_CLASS = Integer.class;
-	private static final Class<Double> DOUBLE_CLASS = Double.class;
-
-	private final NumberSubtract op = new NumberSubtract();
-
+	@Test
 	public void testOperator()
 	{
+		NumberSubtract op = new NumberSubtract();
 		assertNotNull(op.getOperator());
 		assertTrue(op.getOperator().getSymbol().equals("-"));
 	}
 
+	@Test
 	public void testAbstractEvaluateNulls()
 	{
+		NumberSubtract op = new NumberSubtract();
 		try
 		{
 			assertNull(op.abstractEvaluate(null, null, null));
@@ -47,7 +53,7 @@ public class NumberSubtractTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(NUMBER_CLASS, null, null));
+			assertNull(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, null, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -55,7 +61,7 @@ public class NumberSubtractTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(null, NUMBER_CLASS, null));
+			assertNull(op.abstractEvaluate(null, FormatUtilities.NUMBER_CLASS, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -63,84 +69,54 @@ public class NumberSubtractTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testAbstractEvaluateMismatch()
 	{
-		assertTrue(op.abstractEvaluate(BOOLEAN_CLASS, INTEGER_CLASS, null).isEmpty());
-		assertTrue(op.abstractEvaluate(NUMBER_CLASS, BOOLEAN_CLASS, null).isEmpty());
+		NumberSubtract op = new NumberSubtract();
+		assertTrue(op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, TestUtilities.INTEGER_CLASS, null).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.BOOLEAN_CLASS, null).isEmpty());
 	}
 
+	@Test
 	public void testAbstractEvaluateLegal()
 	{
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(NUMBER_CLASS, NUMBER_CLASS, null).get().getManagedClass());
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(DOUBLE_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(INTEGER_CLASS, INTEGER_CLASS, null).get().getManagedClass());
+		NumberSubtract op = new NumberSubtract();
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, FormatUtilities.NUMBER_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(TestUtilities.DOUBLE_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(TestUtilities.INTEGER_CLASS, TestUtilities.INTEGER_CLASS, null).get().getManagedClass());
 		//mixed okay too
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(NUMBER_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(INTEGER_CLASS, DOUBLE_CLASS, null).get().getManagedClass());
-		assertEquals(NUMBER_CLASS,
-			op.abstractEvaluate(DOUBLE_CLASS, INTEGER_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(FormatUtilities.NUMBER_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(TestUtilities.INTEGER_CLASS, TestUtilities.DOUBLE_CLASS, null).get().getManagedClass());
+		assertEquals(FormatUtilities.NUMBER_CLASS,
+			op.abstractEvaluate(TestUtilities.DOUBLE_CLASS, TestUtilities.INTEGER_CLASS, null).get().getManagedClass());
 	}
 
+	@Test
 	public void testEvaluateFailNull()
 	{
-		try
-		{
-			assertNull(op.evaluate(null, null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(Integer.valueOf(0), null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(null, Double.valueOf(4.5)));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
+		NumberSubtract op = new NumberSubtract();
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(Integer.valueOf(0), null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, Double.valueOf(4.5)));
 	}
 
+	@Test
 	public void testEvaluateMismatch()
 	{
-		try
-		{
-			assertNull(op.evaluate(true, Double.valueOf(4.5)));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(new Object(), Double.valueOf(4.5)));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
+		NumberSubtract op = new NumberSubtract();
+		assertThrows(ClassCastException.class, () -> op.evaluate(true, Double.valueOf(4.5)));
+		assertThrows(ClassCastException.class, () -> op.evaluate(new Object(), Double.valueOf(4.5)));
 	}
 
+	@Test
 	public void testEvaluateLegal()
 	{
+		NumberSubtract op = new NumberSubtract();
 		assertEquals(Double.valueOf(0.7),
 			op.evaluate(Integer.valueOf(2), Double.valueOf(1.3)));
 		assertEquals(Integer.valueOf(-2),

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/operator/string/StringAddTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/operator/string/StringAddTest.java
@@ -17,25 +17,30 @@
  */
 package pcgen.base.formula.operator.string;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class StringAddTest extends TestCase
+import org.junit.jupiter.api.Test;
+
+import pcgen.base.formatmanager.FormatUtilities;
+
+public class StringAddTest
 {
-
-	private static final Class<Number> NUMBER_CLASS = Number.class;
-	private static final Class<Boolean> BOOLEAN_CLASS = Boolean.class;
-	private static final Class<String> STRING_CLASS = String.class;
-
-	private final StringAdd op = new StringAdd();
-
+	@Test
 	public void testOperator()
 	{
+		StringAdd op = new StringAdd();
 		assertNotNull(op.getOperator());
 		assertTrue(op.getOperator().getSymbol().equals("+"));
 	}
 
+	@Test
 	public void testAbstractEvaluateNulls()
 	{
+		StringAdd op = new StringAdd();
 		try
 		{
 			assertNull(op.abstractEvaluate(null, null, null));
@@ -46,7 +51,7 @@ public class StringAddTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(STRING_CLASS, null, null));
+			assertNull(op.abstractEvaluate(FormatUtilities.STRING_CLASS, null, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -54,7 +59,7 @@ public class StringAddTest extends TestCase
 		}
 		try
 		{
-			assertNull(op.abstractEvaluate(null, STRING_CLASS, null));
+			assertNull(op.abstractEvaluate(null, FormatUtilities.STRING_CLASS, null));
 		}
 		catch (NullPointerException e)
 		{
@@ -62,73 +67,43 @@ public class StringAddTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testAbstractEvaluateMismatch()
 	{
-		assertTrue(op.abstractEvaluate(BOOLEAN_CLASS, STRING_CLASS, null).isEmpty());
-		assertTrue(op.abstractEvaluate(STRING_CLASS, NUMBER_CLASS, null).isEmpty());
+		StringAdd op = new StringAdd();
+		assertTrue(op.abstractEvaluate(FormatUtilities.BOOLEAN_CLASS, FormatUtilities.STRING_CLASS, null).isEmpty());
+		assertTrue(op.abstractEvaluate(FormatUtilities.STRING_CLASS, FormatUtilities.NUMBER_CLASS, null).isEmpty());
 	}
 
+	@Test
 	public void testAbstractEvaluateLegal()
 	{
-		assertEquals(STRING_CLASS,
-			op.abstractEvaluate(STRING_CLASS, STRING_CLASS, null).get().getManagedClass());
+		StringAdd op = new StringAdd();
+		assertEquals(FormatUtilities.STRING_CLASS,
+			op.abstractEvaluate(FormatUtilities.STRING_CLASS, FormatUtilities.STRING_CLASS, null).get().getManagedClass());
 	}
 
+	@Test
 	public void testEvaluateFailNull()
 	{
-		try
-		{
-			assertNull(op.evaluate(null, null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate("ABC", null));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(null, "DEF"));
-			fail();
-		}
-		catch (NullPointerException e)
-		{
-			//expected
-		}
+		StringAdd op = new StringAdd();
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, null));
+		assertThrows(NullPointerException.class, () -> op.evaluate("ABC", null));
+		assertThrows(NullPointerException.class, () -> op.evaluate(null, "DEF"));
 	}
 
+	@Test
 	public void testEvaluateMismatch()
 	{
-		try
-		{
-			assertNull(op.evaluate("ABC", true));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
-		try
-		{
-			assertNull(op.evaluate(new Object(), "DEF"));
-			fail();
-		}
-		catch (RuntimeException e)
-		{
-			//expected
-		}
+		StringAdd op = new StringAdd();
+		assertThrows(ClassCastException.class, () -> op.evaluate("ABC", true));
+		assertThrows(ClassCastException.class, () -> op.evaluate(new Object(), "DEF"));
 	}
 
+	@Test
 	public void testEvaluateLegal()
 	{
+		StringAdd op = new StringAdd();
 		assertEquals("ABCDEF", op.evaluate("ABC", "DEF"));
 	}
 }

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/parse/FormulaArithmeticTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/parse/FormulaArithmeticTest.java
@@ -17,25 +17,25 @@
  */
 package pcgen.base.formula.parse;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.inst.FormulaUtilities;
 import pcgen.base.formula.visitor.ReconstructionVisitor;
 import pcgen.base.testsupport.AbstractFormulaTestCase;
 import pcgen.base.testsupport.TestUtilities;
-import pcgen.base.util.FormatManager;
 
 public class FormulaArithmeticTest extends AbstractFormulaTestCase
 {
 
-	private static final FormatManager<?> booleanManager =
-			FormatUtilities.BOOLEAN_MANAGER;
-
+	@BeforeEach
 	@Override
-	protected void setUp() throws Exception
+	protected void setUp()
 	{
 		super.setUp();
 		FormulaUtilities.loadBuiltInOperators(getOperatorLibrary());
@@ -599,11 +599,11 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2==3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -614,10 +614,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2==3.2";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -628,10 +628,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.1==3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -642,10 +642,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.1==3.4";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -656,11 +656,11 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2==-3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -671,10 +671,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2==-3.2";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -685,10 +685,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.1==-3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -699,10 +699,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.1==-3.4";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -713,11 +713,11 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-2==3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -728,10 +728,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-2==3.2";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -742,10 +742,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-2.1==3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -756,10 +756,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-2.1==3.4";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -770,10 +770,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "6==6";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -784,10 +784,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-3==-3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -798,10 +798,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "3.3==3.3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -812,10 +812,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-0.3==-0.3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -826,10 +826,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.0==2";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -840,10 +840,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "3==3.0";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -854,11 +854,11 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2!=3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -869,10 +869,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2!=3.2";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -883,10 +883,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.1!=3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -897,10 +897,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.1!=3.4";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -911,11 +911,11 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2!=-3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -926,10 +926,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2!=-3.2";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -940,10 +940,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.1!=-3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -954,10 +954,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.1!=-3.4";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -968,11 +968,11 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-2!=3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -983,10 +983,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-2!=3.2";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -997,10 +997,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-2.1!=3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1011,10 +1011,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-2.1!=3.4";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1025,10 +1025,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "6!=6";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1039,10 +1039,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-3!=-3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1053,10 +1053,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "3.3!=3.3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1067,10 +1067,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-0.3!=-0.3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1081,10 +1081,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.0!=2";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1095,10 +1095,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "3!=3.0";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1109,11 +1109,11 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2<3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1124,10 +1124,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2<3.2";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1138,10 +1138,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.1<3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1152,10 +1152,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.1<3.4";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1166,11 +1166,11 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2<-3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1181,10 +1181,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2<-3.2";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1195,10 +1195,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.1<-3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1209,10 +1209,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.1<-3.4";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1223,11 +1223,11 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-2<3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1238,10 +1238,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-2<3.2";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1252,10 +1252,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-2.1<3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1266,10 +1266,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-2.1<3.4";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1280,10 +1280,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "6<6";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1294,10 +1294,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-3<-3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1308,10 +1308,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "3.3<3.3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1322,10 +1322,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-0.3<-0.3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1336,10 +1336,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.0<2";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1350,10 +1350,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "3<3.0";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1364,11 +1364,11 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2>3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1379,10 +1379,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2>3.2";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1393,10 +1393,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.1>3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1407,10 +1407,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.1>3.4";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1421,11 +1421,11 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2>-3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1436,10 +1436,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2>-3.2";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1450,10 +1450,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.1>-3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1464,10 +1464,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.1>-3.4";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1478,11 +1478,11 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-2>3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1493,10 +1493,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-2>3.2";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1507,10 +1507,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-2.1>3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1521,10 +1521,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-2.1>3.4";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1535,10 +1535,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "6>6";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1549,10 +1549,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-3>-3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1563,10 +1563,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "3.3>3.3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1577,10 +1577,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-0.3>-0.3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1591,10 +1591,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.0>2";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1605,10 +1605,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "3>3.0";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1619,11 +1619,11 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2<=3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1634,10 +1634,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2<=3.2";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1648,10 +1648,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.1<=3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1662,10 +1662,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.1<=3.4";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1676,11 +1676,11 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2<=-3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1691,10 +1691,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2<=-3.2";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1705,10 +1705,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.1<=-3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1719,10 +1719,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.1<=-3.4";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1733,11 +1733,11 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-2<=3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1748,10 +1748,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-4<=3.2";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1762,10 +1762,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-5.1<=3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1776,10 +1776,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-5.1<=3.4";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1790,10 +1790,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "6<=6";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1804,10 +1804,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-3<=-3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1818,10 +1818,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "3.3<=3.3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1832,10 +1832,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-0.3<=-0.3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1846,10 +1846,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.0<=2";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1860,10 +1860,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "3<=3.0";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1874,11 +1874,11 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2>=3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1889,10 +1889,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2>=3.2";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1903,10 +1903,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.1>=3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1917,10 +1917,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.1>=3.4";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1931,11 +1931,11 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2>=-3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1946,10 +1946,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2>=-3.2";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1960,10 +1960,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.1>=-3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1974,10 +1974,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.1>=-3.4";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -1988,11 +1988,11 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-2>=3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		//Note integer math
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2003,10 +2003,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-2>=3.2";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2017,10 +2017,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-2.1>=3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2031,10 +2031,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-2.1>=3.4";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2045,10 +2045,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "6>=6";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2059,10 +2059,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-3>=-3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2073,10 +2073,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "3.3>=3.3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2087,10 +2087,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "-0.3>=-0.3";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2101,10 +2101,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "2.0>=2";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -2115,10 +2115,10 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 	{
 		String formula = "3>=3.0";
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, true);
 		assertTrue(getVariables(node).isEmpty());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -3058,7 +3058,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		String formula = "(4<5)+(5>6)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isNotValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
-		isNotValid(formula, node, booleanManager, Optional.empty());
+		isNotValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 	}
 
 	@Test
@@ -3067,7 +3067,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		String formula = "((4<5)+(5>6))-1";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isNotValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
-		isNotValid(formula, node, booleanManager, Optional.empty());
+		isNotValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 	}
 
 	@Test
@@ -3076,7 +3076,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		String formula = "5+((4<5)+(5>6))";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isNotValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
-		isNotValid(formula, node, booleanManager, Optional.empty());
+		isNotValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 	}
 
 	@Test
@@ -3102,7 +3102,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		String formula = "5^(9>8)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isNotValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
-		isNotValid(formula, node, booleanManager, Optional.empty());
+		isNotValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 	}
 
 
@@ -3112,7 +3112,7 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		String formula = "((4<5)+(5>6))^1";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isNotValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
-		isNotValid(formula, node, booleanManager, Optional.empty());
+		isNotValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 	}
 
 	@Test
@@ -3121,6 +3121,6 @@ public class FormulaArithmeticTest extends AbstractFormulaTestCase
 		String formula = "5^((4<5)+(5>6))";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isNotValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
-		isNotValid(formula, node, booleanManager, Optional.empty());
+		isNotValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 	}
 }

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/parse/FormulaParserTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/parse/FormulaParserTest.java
@@ -17,13 +17,13 @@
  */
 package pcgen.base.formula.parse;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.StringReader;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
-
-public class FormulaParserTest extends TestCase
+public class FormulaParserTest
 {
 
 	private SimpleNode doTest(String formula) throws ParseException
@@ -619,6 +619,7 @@ public class FormulaParserTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testLessThan()
 	{
 		try
@@ -698,6 +699,7 @@ public class FormulaParserTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testGreaterThan()
 	{
 		try
@@ -777,6 +779,7 @@ public class FormulaParserTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testLessThanOrEqualTo()
 	{
 		try
@@ -856,6 +859,7 @@ public class FormulaParserTest extends TestCase
 		}
 	}
 
+	@Test
 	public void testGreaterThanOrEqualTo()
 	{
 		try

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/parse/FormulaVariableTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/parse/FormulaVariableTest.java
@@ -17,10 +17,15 @@
  */
 package pcgen.base.formula.parse;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.OperatorLibrary;
@@ -35,18 +40,15 @@ import pcgen.base.formula.operator.number.NumberSubtract;
 import pcgen.base.formula.visitor.ReconstructionVisitor;
 import pcgen.base.testsupport.AbstractFormulaTestCase;
 import pcgen.base.testsupport.TestUtilities;
-import pcgen.base.util.FormatManager;
 
 public class FormulaVariableTest extends AbstractFormulaTestCase
 {
 
-	private static final FormatManager<?> booleanManager =
-			FormatUtilities.BOOLEAN_MANAGER;
-
 	private WriteableVariableStore store;
 
+	@BeforeEach
 	@Override
-	protected void setUp() throws Exception
+	protected void setUp()
 	{
 		super.setUp();
 		store = getVariableStore();
@@ -57,6 +59,14 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 		operatorLibrary.addAction(new NumberSubtract());
 		operatorLibrary.addAction(new NumberDivide());
 		operatorLibrary.addAction(new NumberMultiply());
+	}
+	
+	@AfterEach
+	@Override
+	protected void tearDown()
+	{
+		super.tearDown();
+		store = null;
 	}
 
 	@Test
@@ -212,11 +222,11 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 		store.put(getVariable("a"), 3.2);
 		store.put(getVariable("b"), 2.1);
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, false);
 		hasABVars(node);
 		//Note integer math
-		evaluatesTo(booleanManager, formula, node, Boolean.FALSE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -230,7 +240,7 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 		getVariableStore().put(getBooleanVariable("b"), false);
 		SimpleNode node = TestUtilities.doParse(formula);
 		isNotValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
-		isNotValid(formula, node, booleanManager, Optional.empty());
+		isNotValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 	}
 
 	@Test
@@ -240,11 +250,11 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 		store.put(getVariable("a"), 0.0);
 		store.put(getVariable("b"), 0);
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, false);
 		hasABVars(node);
 		//Note integer math
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -257,11 +267,11 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 		store.put(getVariable("a"), -2.1);
 		store.put(getVariable("b"), -2.1);
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, false);
 		hasABVars(node);
 		//Note integer math
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));
@@ -393,13 +403,13 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 		String formula = "!a";
 		store.put(getBooleanVariable("a"), Boolean.FALSE);
 		SimpleNode node = TestUtilities.doParse(formula);
-		isValid(formula, node, booleanManager, Optional.empty());
+		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, false);
 		List<VariableID<?>> vars = getVariables(node);
 		assertEquals(1, vars.size());
 		VariableID<?> var0 = vars.get(0);
 		assertEquals("a", var0.getName());
-		evaluatesTo(booleanManager, formula, node, Boolean.TRUE);
+		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.TRUE);
 		Object rv =
 				new ReconstructionVisitor().visit(node, new StringBuilder());
 		assertTrue(rv.toString().equals(formula));

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/AggressiveSolverManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/AggressiveSolverManagerTest.java
@@ -15,14 +15,18 @@
  */
 package pcgen.base.solver;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.FormulaManager;
 import pcgen.base.formula.base.LegalScope;
-import pcgen.base.formula.base.ManagerFactory;
 import pcgen.base.formula.base.ScopeInstance;
 import pcgen.base.formula.base.VariableID;
 import pcgen.base.formula.base.WriteableVariableStore;
@@ -31,61 +35,37 @@ import pcgen.base.formula.inst.SimpleLegalScope;
 import pcgen.base.solver.testsupport.AbstractModifier;
 import pcgen.base.solver.testsupport.AbstractSolverManagerTest;
 import pcgen.base.solver.testsupport.MockStat;
+import pcgen.base.testsupport.TestUtilities;
 
 public class AggressiveSolverManagerTest extends AbstractSolverManagerTest
 {
-	private ManagerFactory managerFactory = new ManagerFactory(){};
 	private AggressiveSolverManager manager;
 
+	@BeforeEach
 	@Override
-	protected void setUp() throws Exception
+	protected void setUp()
 	{
 		super.setUp();
-		manager = new AggressiveSolverManager(getFormulaManager(), managerFactory,
+		manager = new AggressiveSolverManager(getFormulaManager(), TestUtilities.EMPTY_MGR_FACTORY,
 			getSolverFactory(), getVariableStore());
 	}
+	
+	@AfterEach
+	@Override
+	protected void tearDown()
+	{
+		super.tearDown();
+		manager = null;
+	}
 
-	@SuppressWarnings("unused")
 	@Test
 	public void testIllegalConstruction()
 	{
-		try
-		{
-			new AggressiveSolverManager(null, managerFactory, getSolverFactory(), getVariableStore());
-			fail("No nulls in constructor");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
+		assertThrows(NullPointerException.class, () -> new AggressiveSolverManager(null, TestUtilities.EMPTY_MGR_FACTORY, getSolverFactory(), getVariableStore()));
 		FormulaManager formulaManager = getFormulaManager();
-		try
-		{
-			new AggressiveSolverManager(formulaManager, null, getSolverFactory(), getVariableStore());
-			fail("No nulls in constructor");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
-		try
-		{
-			new AggressiveSolverManager(formulaManager, managerFactory, getSolverFactory(), null);
-			fail("No nulls in constructor");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
-		try
-		{
-			new AggressiveSolverManager(formulaManager, managerFactory, getSolverFactory(), null);
-			fail("No nulls in constructor");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
+		assertThrows(NullPointerException.class, () -> new AggressiveSolverManager(formulaManager, null, getSolverFactory(), getVariableStore()));
+		assertThrows(NullPointerException.class, () -> new AggressiveSolverManager(formulaManager, TestUtilities.EMPTY_MGR_FACTORY, getSolverFactory(), null));
+		assertThrows(NullPointerException.class, () -> new AggressiveSolverManager(formulaManager, TestUtilities.EMPTY_MGR_FACTORY, getSolverFactory(), null));
 	}
 
 	@Test

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/ArrayComponentModifierTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/ArrayComponentModifierTest.java
@@ -17,62 +17,36 @@
  */
 package pcgen.base.solver;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import pcgen.base.format.ArrayFormatManager;
-import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.EvaluationManager;
 import pcgen.base.solver.testsupport.AbstractModifier;
 import pcgen.base.testsupport.AbstractFormulaTestCase;
-import pcgen.base.util.FormatManager;
+import pcgen.base.testsupport.TestUtilities;
 
 public class ArrayComponentModifierTest extends AbstractFormulaTestCase
 {
-	private final FormatManager<Number[]> NAF =
-			new ArrayFormatManager<>(FormatUtilities.NUMBER_MANAGER, '\n', ',');
-
-	@SuppressWarnings("unused")
 	@Test
 	public void testConstructor()
 	{
-		try
-		{
-			Modifier<Number> cm = AbstractModifier.setNumber(3, 100);
-			new ArrayComponentModifier<>(null, 5, cm);
-			fail();
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
-		try
-		{
-			new ArrayComponentModifier<>(NAF, 5, null);
-			fail();
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
-		try
-		{
-			Modifier<Number> cm = AbstractModifier.setNumber(3, 100);
-			new ArrayComponentModifier<>(NAF, -5, cm);
-			fail();
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
+		Modifier<Number> cm = AbstractModifier.setNumber(3, 100);
+		assertThrows(NullPointerException.class, () -> new ArrayComponentModifier<>(null, 5, cm));
+		assertThrows(NullPointerException.class, () -> new ArrayComponentModifier<>(TestUtilities.NUMBER_ARRAY_MANAGER, 5, null));
+		assertThrows(IllegalArgumentException.class, () -> new ArrayComponentModifier<>(TestUtilities.NUMBER_ARRAY_MANAGER, -5, cm));
 	}
 
 	@Test
 	public void testGetUserPriority()
 	{
 		Modifier<Number> cm = AbstractModifier.setNumber(3, 100);
-		ArrayComponentModifier<Number> acm = new ArrayComponentModifier<>(NAF, 5, cm);
+		ArrayComponentModifier<Number> acm = new ArrayComponentModifier<>(TestUtilities.NUMBER_ARRAY_MANAGER, 5, cm);
 		assertEquals((100L << 32), acm.getPriority());
 	}
 
@@ -80,8 +54,8 @@ public class ArrayComponentModifierTest extends AbstractFormulaTestCase
 	public void testGetVariableFormat()
 	{
 		Modifier<Number> cm = AbstractModifier.setNumber(3, 100);
-		ArrayComponentModifier<Number> acm = new ArrayComponentModifier<>(NAF, 5, cm);
-		assertEquals(NAF, acm.getVariableFormat());
+		ArrayComponentModifier<Number> acm = new ArrayComponentModifier<>(TestUtilities.NUMBER_ARRAY_MANAGER, 5, cm);
+		assertEquals(TestUtilities.NUMBER_ARRAY_MANAGER, acm.getVariableFormat());
 		assertEquals(Number[].class, acm.getVariableFormat().getManagedClass());
 	}
 
@@ -89,7 +63,7 @@ public class ArrayComponentModifierTest extends AbstractFormulaTestCase
 	public void testGetIdentification()
 	{
 		Modifier<Number> cm = AbstractModifier.setNumber(3, 100);
-		ArrayComponentModifier<Number> acm = new ArrayComponentModifier<>(NAF, 5, cm);
+		ArrayComponentModifier<Number> acm = new ArrayComponentModifier<>(TestUtilities.NUMBER_ARRAY_MANAGER, 5, cm);
 		assertEquals("Set (component)", acm.getIdentification());
 	}
 
@@ -97,7 +71,7 @@ public class ArrayComponentModifierTest extends AbstractFormulaTestCase
 	public void testGetInstructions()
 	{
 		Modifier<Number> cm = AbstractModifier.setNumber(3, 100);
-		ArrayComponentModifier<Number> acm = new ArrayComponentModifier<>(NAF, 5, cm);
+		ArrayComponentModifier<Number> acm = new ArrayComponentModifier<>(TestUtilities.NUMBER_ARRAY_MANAGER, 5, cm);
 		assertEquals("To [5]: +3", acm.toString());
 	}
 
@@ -105,7 +79,7 @@ public class ArrayComponentModifierTest extends AbstractFormulaTestCase
 	public void testProcess()
 	{
 		Modifier<Number> cm = AbstractModifier.setNumber(8, 100);
-		ArrayComponentModifier<Number> acm = new ArrayComponentModifier<>(NAF, 5, cm);
+		ArrayComponentModifier<Number> acm = new ArrayComponentModifier<>(TestUtilities.NUMBER_ARRAY_MANAGER, 5, cm);
 		Number[] array = {1, 2, 3, 4, 5, 6, 7};
 		EvaluationManager manager = generateManager(array);
 		Object[] result = acm.process(manager);
@@ -119,7 +93,7 @@ public class ArrayComponentModifierTest extends AbstractFormulaTestCase
 	public void testProcessOutOfBounds()
 	{
 		Modifier<Number> cm = AbstractModifier.setNumber(77, 100);
-		ArrayComponentModifier<Number> acm = new ArrayComponentModifier<>(NAF, 5, cm);
+		ArrayComponentModifier<Number> acm = new ArrayComponentModifier<>(TestUtilities.NUMBER_ARRAY_MANAGER, 5, cm);
 		Number[] array = {1, 2, 3, 4};
 		//Should be no effect
 		EvaluationManager manager = generateManager(array);

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/DynamicSolverManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/DynamicSolverManagerTest.java
@@ -15,9 +15,14 @@
  */
 package pcgen.base.solver;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.DependencyManager;
@@ -28,7 +33,6 @@ import pcgen.base.formula.base.FormulaManager;
 import pcgen.base.formula.base.FormulaSemantics;
 import pcgen.base.formula.base.FunctionLibrary;
 import pcgen.base.formula.base.LegalScope;
-import pcgen.base.formula.base.ManagerFactory;
 import pcgen.base.formula.base.ScopeInstance;
 import pcgen.base.formula.base.ScopeInstanceFactory;
 import pcgen.base.formula.base.TrainingStrategy;
@@ -45,77 +49,50 @@ import pcgen.base.formula.visitor.SemanticsVisitor;
 import pcgen.base.formula.visitor.StaticVisitor;
 import pcgen.base.solver.testsupport.AbstractModifier;
 import pcgen.base.solver.testsupport.AbstractSolverManagerTest;
+import pcgen.base.testsupport.TestUtilities;
 import pcgen.base.util.BasicIndirect;
 import pcgen.base.util.CaseInsensitiveMap;
 import pcgen.base.util.FormatManager;
 import pcgen.base.util.Indirect;
-import pcgen.base.util.TypedKey;
 
 public class DynamicSolverManagerTest extends AbstractSolverManagerTest
 {
-	private ManagerFactory managerFactory = new ManagerFactory()
-	{
-	};
 	private DynamicSolverManager manager;
 	private LimbManager limbManager;
-	public static final TypedKey<ScopeInstanceFactory> SIFACTORY = new TypedKey<>();
 
+	@BeforeEach
 	@Override
-	protected void setUp() throws Exception
+	protected void setUp()
 	{
 		super.setUp();
-		manager = new DynamicSolverManager(getFormulaManager(), managerFactory,
+		manager = new DynamicSolverManager(getFormulaManager(), TestUtilities.EMPTY_MGR_FACTORY,
 			getSolverFactory(), getVariableStore());
 		limbManager = new LimbManager();
 		getSolverFactory().addSolverFormat(limbManager,
 			() -> limbManager.convert("Head"));
 	}
+	
+	@AfterEach
+	@Override
+	protected void tearDown()
+	{
+		super.tearDown();
+		manager = null;
+		limbManager = null;
+	}
 
-	@SuppressWarnings("unused")
 	@Test
 	public void testIllegalConstruction()
 	{
-		try
-		{
-			new DynamicSolverManager(null, managerFactory, getSolverFactory(),
-				getVariableStore());
-			fail("No nulls in constructor");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
+		assertThrows(NullPointerException.class, () -> new DynamicSolverManager(null, TestUtilities.EMPTY_MGR_FACTORY, getSolverFactory(),
+				getVariableStore()));
 		FormulaManager formulaManager = getFormulaManager();
-		try
-		{
-			new DynamicSolverManager(formulaManager, null, getSolverFactory(),
-				getVariableStore());
-			fail("No nulls in constructor");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
-		try
-		{
-			new DynamicSolverManager(formulaManager, managerFactory, null,
-				getVariableStore());
-			fail("No nulls in constructor");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
-		try
-		{
-			new DynamicSolverManager(formulaManager, managerFactory, getSolverFactory(),
-				null);
-			fail("No nulls in constructor");
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
+		assertThrows(NullPointerException.class, () -> new DynamicSolverManager(formulaManager, null, getSolverFactory(),
+				getVariableStore()));
+		assertThrows(NullPointerException.class, () -> new DynamicSolverManager(formulaManager, TestUtilities.EMPTY_MGR_FACTORY, null,
+				getVariableStore()));
+		assertThrows(NullPointerException.class, () -> new DynamicSolverManager(formulaManager, TestUtilities.EMPTY_MGR_FACTORY, getSolverFactory(),
+				null));
 	}
 
 	@Override
@@ -350,6 +327,7 @@ public class DynamicSolverManagerTest extends AbstractSolverManagerTest
 		}
 	}
 
+	@Test
 	public void testAnother()
 	{
 		ScopeInstance source = getGlobalScopeInst();
@@ -410,7 +388,6 @@ public class DynamicSolverManagerTest extends AbstractSolverManagerTest
 		manager.addModifier(altID, four, altInst);
 		assertEquals(4, store.get(resultID));
 	}
-
 
 	@Override
 	protected FormulaManager getFormulaManager()

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/testsupport/AbstractSolverManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/testsupport/AbstractSolverManagerTest.java
@@ -15,9 +15,16 @@
  */
 package pcgen.base.solver.testsupport;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.LegalScope;
@@ -44,8 +51,9 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 	private LegalScope globalScope;
 	private ScopeInstance globalScopeInst;
 
+	@BeforeEach
 	@Override
-	protected void setUp() throws Exception
+	protected void setUp()
 	{
 		super.setUp();
 		solverFactory = new SimpleSolverFactory(getValueStore());
@@ -55,6 +63,18 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 		globalScopeInst = getGlobalScopeInst();
 	}
 
+	@AfterEach
+	@Override
+	protected void tearDown()
+	{
+		super.tearDown();
+		solverFactory = null;
+		varLibrary = null;
+		store = null;
+		globalScope = null;
+		globalScopeInst = null;
+	}
+
 	protected abstract SolverManager getManager();
 
 	@Test
@@ -62,15 +82,7 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 	{
 		varLibrary.assertLegalVariableID("HP", globalScope,
 			FormatUtilities.NUMBER_MANAGER);
-		try
-		{
-			getManager().createChannel(null);
-			fail();
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
+		assertThrows(NullPointerException.class, () -> getManager().createChannel(null));
 	}
 
 	@Test
@@ -82,15 +94,7 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 		VariableID<Number> hp =
 				(VariableID<Number>) varLibrary.getVariableID(globalScopeInst, "HP");
 		getManager().createChannel(hp);
-		try
-		{
-			getManager().createChannel(hp);
-			fail();
-		}
-		catch (IllegalArgumentException e)
-		{
-			//ok
-		}
+		assertThrows(IllegalArgumentException.class, () -> getManager().createChannel(hp));
 	}
 
 	@Test
@@ -117,33 +121,9 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 		getManager().createChannel(hp);
 		AbstractModifier<Number> modifier = AbstractModifier.setNumber(6, 5);
 		ScopeInstance source = globalScopeInst;
-		try
-		{
-			getManager().addModifier(null, modifier, source);
-			fail();
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
-		try
-		{
-			getManager().addModifier(hp, null, source);
-			fail();
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
-		try
-		{
-			getManager().addModifier(hp, modifier, null);
-			fail();
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
+		assertThrows(NullPointerException.class, () -> getManager().addModifier(null, modifier, source));
+		assertThrows(NullPointerException.class, () -> getManager().addModifier(hp, null, source));
+		assertThrows(NullPointerException.class, () -> getManager().addModifier(hp, modifier, null));
 		//Invalid ID very bad
 		VariableLibrary alternateLibrary = new VariableManager(getScopeManager(), getValueStore());
 		alternateLibrary.assertLegalVariableID("brains", globalScope,
@@ -151,15 +131,7 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 		@SuppressWarnings("unchecked")
 		VariableID<Number> brains = (VariableID<Number>) alternateLibrary
 			.getVariableID(globalScopeInst, "Brains");
-		try
-		{
-			getManager().addModifier(brains, modifier, source);
-			fail("Didn't own that VarID!");
-		}
-		catch (IllegalArgumentException e)
-		{
-			//ok
-		}
+		assertThrows(IllegalArgumentException.class, () -> getManager().addModifier(brains, modifier, source));
 	}
 
 	@Test
@@ -313,33 +285,9 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 		getManager().createChannel(hp);
 		AbstractModifier<Number> modifier = AbstractModifier.setNumber(6, 5);
 		ScopeInstance source = globalScopeInst;
-		try
-		{
-			getManager().removeModifier(null, modifier, source);
-			fail();
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
-		try
-		{
-			getManager().removeModifier(hp, null, source);
-			fail();
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
-		try
-		{
-			getManager().removeModifier(hp, modifier, null);
-			fail();
-		}
-		catch (IllegalArgumentException | NullPointerException e)
-		{
-			//ok
-		}
+		assertThrows(NullPointerException.class, () -> getManager().removeModifier(null, modifier, source));
+		assertThrows(NullPointerException.class, () -> getManager().removeModifier(hp, null, source));
+		assertThrows(NullPointerException.class, () -> getManager().removeModifier(hp, modifier, null));
 		//Not present is Harmless
 		getManager().removeModifier(hp, modifier, source);
 		//Invalid ID very bad
@@ -349,15 +297,7 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 		@SuppressWarnings("unchecked")
 		VariableID<Number> brains = (VariableID<Number>) alternateLibrary
 			.getVariableID(globalScopeInst, "Brains");
-		try
-		{
-			getManager().removeModifier(brains, modifier, source);
-			fail("Didn't own that VarID!");
-		}
-		catch (IllegalArgumentException e)
-		{
-			//ok
-		}
+		assertThrows(IllegalArgumentException.class, () -> getManager().removeModifier(brains, modifier, source));
 	}
 
 	@Test

--- a/PCGen-Formula/code/src/test/pcgen/base/testsupport/TestUtilities.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/testsupport/TestUtilities.java
@@ -18,17 +18,59 @@
 package pcgen.base.testsupport;
 
 import java.io.StringReader;
+import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
 import junit.framework.TestCase;
+import pcgen.base.format.ArrayFormatManager;
+import pcgen.base.format.BooleanManager;
+import pcgen.base.format.NumberManager;
+import pcgen.base.formatmanager.ArrayFormatFactory;
+import pcgen.base.formatmanager.CompoundFormatFactory;
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.formula.base.ManagerFactory;
 import pcgen.base.formula.parse.FormulaParser;
 import pcgen.base.formula.parse.ParseException;
 import pcgen.base.formula.parse.SimpleNode;
+import pcgen.base.util.FormatManager;
 
 public final class TestUtilities
 {
 	public static final double SMALL_ERROR = Math.pow(10, -10);
+
+	public static final Number[] EMPTY_ARRAY = {};
+
+	public static final ManagerFactory EMPTY_MGR_FACTORY = new ManagerFactory()
+	{
+	};
+
+	public static final ArrayFormatFactory ARRAY_FACTORY =
+			new ArrayFormatFactory('\n', ',');
+	public static final ArrayFormatManager<Number> NUMBER_ARRAY_MANAGER =
+			new ArrayFormatManager<>(new NumberManager(), '\n', ',');
+	public static final FormatManager<Boolean[]> BOOLEAN_ARRAY_MANAGER =
+			new ArrayFormatManager<>(new BooleanManager(), ',', '|');
+	
+	public static final CompoundFormatFactory COMPOUND_MANAGER =
+			new CompoundFormatFactory(',', '|');
+
+	public static final Class<Float> FLOAT_CLASS = Float.class;
+	public static final Class<Integer> INTEGER_CLASS = Integer.class;
+	public static final Class<Double> DOUBLE_CLASS = Double.class;
+
+	@SuppressWarnings("unchecked")
+	public static final Class<Number[]> NUMBER_ARRAY_CLASS =
+			(Class<Number[]>) Array.newInstance(FormatUtilities.NUMBER_CLASS, 0).getClass();
+	@SuppressWarnings("unchecked")
+	public static final Class<Object[]> OBJECT_ARRAY_CLASS =
+			(Class<Object[]>) Array.newInstance(Object.class, 0).getClass();
+	@SuppressWarnings("unchecked")
+	public static final Class<Boolean[]> BOOLEAN_ARRAY_CLASS =
+			(Class<Boolean[]>) Array.newInstance(FormatUtilities.BOOLEAN_CLASS, 0).getClass();
+	@SuppressWarnings("unchecked")
+	public static final Class<Integer[]> INTEGER_ARRAY_CLASS =
+			(Class<Integer[]>) Array.newInstance(INTEGER_CLASS, 0).getClass();
 
 
 	private TestUtilities()

--- a/PCGen-Formula/code/src/test/pcgen/base/testsupport/TestUtilities.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/testsupport/TestUtilities.java
@@ -72,7 +72,6 @@ public final class TestUtilities
 	public static final Class<Integer[]> INTEGER_ARRAY_CLASS =
 			(Class<Integer[]>) Array.newInstance(INTEGER_CLASS, 0).getClass();
 
-
 	private TestUtilities()
 	{
 		//Do not instantiate utility class


### PR DESCRIPTION
This is a large update, basically bringing the tests to JUnit5 and associated items (like using assertThrows)
During that process, a number of reused items were found, and those were brought to a central location for consistency/reuse.  Most constants were extracted to common locations.
tearDown() was also added for items where class fields were necessary