### PR TITLE
Test Updates - centralization for future simplicity

### DIFF
--- a/PCGen-Formula/code/src/test/pcgen/base/formula/base/VariableIDTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/base/VariableIDTest.java
@@ -22,41 +22,29 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 
 import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.formula.inst.GlobalVarScoped;
 import pcgen.base.formula.inst.ScopeManagerInst;
 import pcgen.base.formula.inst.SimpleLegalScope;
 import pcgen.base.formula.inst.SimpleScopeInstanceFactory;
 
 public class VariableIDTest
 {
-
-	private ScopeManagerInst legalScopeManager;
-	private ScopeInstanceFactory instanceFactory;
-
-	@BeforeEach
-	void setUp()
-	{
-		legalScopeManager = new ScopeManagerInst();
-		legalScopeManager.registerScope(new SimpleLegalScope("Global"));
-		instanceFactory = new SimpleScopeInstanceFactory(legalScopeManager);
-	}
-
-	@AfterEach
-	void tearDown()
-	{
-		legalScopeManager = null;
-		instanceFactory = null;
-	}
-
 	@Test
 	public void testDoubleConstructor()
 	{
+		ScopeManagerInst legalScopeManager = new ScopeManagerInst();
+		ScopeInstanceFactory instanceFactory =
+				new SimpleScopeInstanceFactory(legalScopeManager);
+		legalScopeManager.registerScope(new SimpleLegalScope("Global"));
+		ScopeInstance globalInst = instanceFactory.get("Global",
+			Optional.of(new GlobalVarScoped("Global")));
+
 		assertThrows(NullPointerException.class, () -> new VariableID<>(null, null, null));
-		ScopeInstance globalInst = instanceFactory.getGlobalInstance("Global");
 		assertThrows(NullPointerException.class, () -> new VariableID<>(globalInst, FormatUtilities.NUMBER_MANAGER, null));
 		assertThrows(NullPointerException.class, () -> new VariableID<>(globalInst, null, "VAR"));
 		assertThrows(NullPointerException.class, () -> new VariableID<>(null, FormatUtilities.NUMBER_MANAGER, "VAR"));
@@ -67,7 +55,13 @@ public class VariableIDTest
 	@Test
 	public void testGlobal()
 	{
-		ScopeInstance globalInst = instanceFactory.getGlobalInstance("Global");
+		ScopeManagerInst legalScopeManager = new ScopeManagerInst();
+		ScopeInstanceFactory instanceFactory =
+				new SimpleScopeInstanceFactory(legalScopeManager);
+		legalScopeManager.registerScope(new SimpleLegalScope("Global"));
+		ScopeInstance globalInst = instanceFactory.get("Global",
+			Optional.of(new GlobalVarScoped("Global")));
+
 		VariableID<Number> vid = new VariableID<>(globalInst, FormatUtilities.NUMBER_MANAGER, "test");
 		assertEquals("test", vid.getName());
 		assertEquals(globalInst, vid.getScope());
@@ -77,9 +71,16 @@ public class VariableIDTest
 	@Test
 	public void testEquals()
 	{
-		ScopeInstance globalInst = instanceFactory.getGlobalInstance("Global");
+		ScopeManagerInst legalScopeManager = new ScopeManagerInst();
+		ScopeInstanceFactory instanceFactory =
+				new SimpleScopeInstanceFactory(legalScopeManager);
+		legalScopeManager.registerScope(new SimpleLegalScope("Global"));
+		ScopeInstance globalInst = instanceFactory.get("Global",
+			Optional.of(new GlobalVarScoped("Global")));
 		legalScopeManager.registerScope(new SimpleLegalScope("Global2"));
-		ScopeInstance globalInst2 = instanceFactory.getGlobalInstance("Global2");
+		ScopeInstance globalInst2 = instanceFactory.get("Global2",
+			Optional.of(new GlobalVarScoped("Global2")));
+
 		VariableID<Number> vid1 = new VariableID<>(globalInst, FormatUtilities.NUMBER_MANAGER, "test");
 		VariableID<Number> vid2 = new VariableID<>(globalInst, FormatUtilities.NUMBER_MANAGER, "test");
 		VariableID<Number> vid3 = new VariableID<>(globalInst, FormatUtilities.NUMBER_MANAGER, "test2");
@@ -96,9 +97,16 @@ public class VariableIDTest
 	@Test
 	public void testHashCode()
 	{
-		ScopeInstance globalInst = instanceFactory.getGlobalInstance("Global");
+		ScopeManagerInst legalScopeManager = new ScopeManagerInst();
+		ScopeInstanceFactory instanceFactory =
+				new SimpleScopeInstanceFactory(legalScopeManager);
+		legalScopeManager.registerScope(new SimpleLegalScope("Global"));
+		ScopeInstance globalInst = instanceFactory.get("Global",
+			Optional.of(new GlobalVarScoped("Global")));
 		legalScopeManager.registerScope(new SimpleLegalScope("Global2"));
-		ScopeInstance globalInst2 = instanceFactory.getGlobalInstance("Global2");
+		ScopeInstance globalInst2 = instanceFactory.get("Global2",
+			Optional.of(new GlobalVarScoped("Global2")));
+
 		VariableID<Number> vid1 = new VariableID<>(globalInst, FormatUtilities.NUMBER_MANAGER, "test");
 		VariableID<Number> vid2 = new VariableID<>(globalInst, FormatUtilities.NUMBER_MANAGER, "test");
 		VariableID<Number> vid3 = new VariableID<>(globalInst, FormatUtilities.NUMBER_MANAGER, "bummer");
@@ -112,5 +120,4 @@ public class VariableIDTest
 		assertFalse(hc2 == hc4);
 		assertFalse(hc3 == hc4);
 	}
-
 }

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/AbsFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/AbsFunctionTest.java
@@ -140,7 +140,7 @@ public class AbsFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testVariable()
 	{
-		getVariableStore().put(getVariable("a"), -5);
+		setVariable(getVariable("a"), -5);
 		String formula = "abs(a)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/CeilFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/CeilFunctionTest.java
@@ -157,7 +157,7 @@ public class CeilFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testVariable()
 	{
-		getVariableStore().put(getVariable("a"), 4.5);
+		setVariable(getVariable("a"), 4.5);
 		String formula = "ceil(a)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/FloorFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/FloorFunctionTest.java
@@ -144,7 +144,7 @@ public class FloorFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testVariable()
 	{
-		getVariableStore().put(getVariable("a"), 5.3);
+		setVariable(getVariable("a"), 5.3);
 		String formula = "floor(a)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/GetOptionalFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/GetOptionalFunctionTest.java
@@ -20,14 +20,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import pcgen.base.formatmanager.FormatUtilities;
-import pcgen.base.formatmanager.OptionalFormatFactory;
-import pcgen.base.formatmanager.SimpleFormatManagerLibrary;
 import pcgen.base.formula.base.VariableID;
-import pcgen.base.formula.base.VariableLibrary;
 import pcgen.base.formula.parse.SimpleNode;
 import pcgen.base.testsupport.AbstractFormulaTestCase;
 import pcgen.base.testsupport.TestUtilities;
@@ -37,27 +32,12 @@ import pcgen.base.util.FormatManager;
 public class GetOptionalFunctionTest extends AbstractFormulaTestCase
 {
 
-	SimpleFormatManagerLibrary library;
-	FormatManager<Optional<Number>> formatManager;
-
-	@SuppressWarnings("unchecked")
-	@Override
-	@BeforeEach
-	protected void setUp()
-	{
-		super.setUp();
-		library = new SimpleFormatManagerLibrary();
-		FormatUtilities.loadDefaultFormats(library);
-		FormatUtilities.loadDefaultFactories(library);
-		formatManager = (FormatManager<Optional<Number>>) new OptionalFormatFactory()
-			.build(Optional.empty(), Optional.of("NUMBER"), library);
-	}
-
 	@Test
 	public void testInvalidTooManyArg()
 	{
-		getVariableStore().put(getOptionalVariable("a"), Optional.of(3));
-		getVariableStore().put(getOptionalVariable("b"), Optional.of(3));
+		FormatManager<Optional<Number>> formatManager = getOptionalFormatManager();
+		setVariable(getOptionalVariable("a"), Optional.of(3));
+		setVariable(getOptionalVariable("b"), Optional.of(3));
 		String formula = "getOptional(a, b)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isNotValid(formula, node, formatManager, Optional.empty());
@@ -66,6 +46,7 @@ public class GetOptionalFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testNotValidString()
 	{
+		FormatManager<Optional<Number>> formatManager = getOptionalFormatManager();
 		String formula = "getOptional(\"ab\")";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isNotValid(formula, node, formatManager, Optional.empty());
@@ -74,6 +55,7 @@ public class GetOptionalFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testNotValidNoVar()
 	{
+		FormatManager<Optional<Number>> formatManager = getOptionalFormatManager();
 		String formula = "getOptional(ab)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isNotValid(formula, node, formatManager, Optional.empty());
@@ -82,7 +64,8 @@ public class GetOptionalFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testVariable()
 	{
-		getVariableStore().put(getOptionalVariable("a"), Optional.of(3));
+		FormatManager<Optional<Number>> formatManager = getOptionalFormatManager();
+		setVariable(getOptionalVariable("a"), Optional.of(3));
 		String formula = "getOptional(a)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, formatManager, Optional.empty());
@@ -97,7 +80,8 @@ public class GetOptionalFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testNullVariable()
 	{
-		getVariableStore().put(getOptionalVariable("a"), Optional.empty());
+		FormatManager<Optional<Number>> formatManager = getOptionalFormatManager();
+		setVariable(getOptionalVariable("a"), Optional.empty());
 		String formula = "getOptional(a)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, formatManager, Optional.empty());
@@ -108,17 +92,4 @@ public class GetOptionalFunctionTest extends AbstractFormulaTestCase
 		assertEquals("a", var.getName());
 		evaluatesTo(formatManager, formula, node, Integer.valueOf(0));
 	}
-
-	protected VariableID<Optional<Number>> getOptionalVariable(String formula)
-	{
-		VariableLibrary variableLibrary = getVariableLibrary();
-		variableLibrary.assertLegalVariableID(formula,
-			getInstanceFactory().getScope("Global"), formatManager);
-		@SuppressWarnings("unchecked")
-		VariableID<Optional<Number>> variableID =
-				(VariableID<Optional<Number>>) variableLibrary
-					.getVariableID(getGlobalScopeInst(), formula);
-		return variableID;
-	}
-
 }

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/IfFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/IfFunctionTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Test;
 
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.VariableID;
-import pcgen.base.formula.base.WriteableVariableStore;
 import pcgen.base.formula.parse.SimpleNode;
 import pcgen.base.formula.visitor.ReconstructionVisitor;
 import pcgen.base.testsupport.AbstractFormulaTestCase;
@@ -212,7 +211,7 @@ public class IfFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testVar()
 	{
-		getVariableStore().put(getVariable("a"), 5);
+		setVariable(getVariable("a"), 5);
 		String formula = "if(4.6>0,a,8.1)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
@@ -227,10 +226,9 @@ public class IfFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testManyVar()
 	{
-		WriteableVariableStore variableStore = getVariableStore();
-		variableStore.put(getVariable("a"), -5);
-		variableStore.put(getVariable("b"), 5.1);
-		variableStore.put(getVariable("c"), 3);
+		setVariable(getVariable("a"), -5);
+		setVariable(getVariable("b"), 5.1);
+		setVariable(getVariable("c"), 3);
 		String formula = "if(a>0,b,c)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
@@ -251,11 +249,11 @@ public class IfFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testVariable1()
 	{
-		getVariableLibrary().assertLegalVariableID("a", getInstanceFactory().getScope("Global"), FormatUtilities.BOOLEAN_MANAGER);
+		assertLegalVariable("a", "Global", FormatUtilities.BOOLEAN_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Boolean> variable =
 				(VariableID<Boolean>) getVariableLibrary().getVariableID(getGlobalScopeInst(), "a");
-		getVariableStore().put(variable, true);
+		setVariable(variable, true);
 		String formula = "if(a, 4, 5)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
@@ -269,7 +267,7 @@ public class IfFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testVariable2()
 	{
-		getVariableStore().put(getVariable("a"), 5);
+		setVariable(getVariable("a"), 5);
 		String formula = "if(4<5, a, 3.4)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
@@ -283,7 +281,7 @@ public class IfFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testVariable3()
 	{
-		getVariableStore().put(getVariable("a"), 5);
+		setVariable(getVariable("a"), 5);
 		String formula = "if(4<3, 3.4, a)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/IsEmptyFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/IsEmptyFunctionTest.java
@@ -23,9 +23,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 import pcgen.base.formatmanager.FormatUtilities;
-import pcgen.base.formula.base.ScopeInstance;
 import pcgen.base.formula.base.VariableID;
-import pcgen.base.formula.base.VariableLibrary;
 import pcgen.base.formula.parse.SimpleNode;
 import pcgen.base.testsupport.AbstractFormulaTestCase;
 import pcgen.base.testsupport.TestUtilities;
@@ -60,7 +58,7 @@ public class IsEmptyFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testEmptyArrayVar()
 	{
-		getVariableStore().put(getArrayVariable("a"), TestUtilities.EMPTY_ARRAY);
+		setVariable(getNumberArrayVar("a"), TestUtilities.EMPTY_ARRAY);
 		String formula = "isEmpty(a)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, TestUtilities.NUMBER_ARRAY_MANAGER, Optional.empty());
@@ -75,7 +73,7 @@ public class IsEmptyFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testNotEmptyArrayVar()
 	{
-		getVariableStore().put(getArrayVariable("a"), new Number[]{1});
+		setVariable(getNumberArrayVar("a"), new Number[]{1});
 		String formula = "isEmpty(a)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, TestUtilities.NUMBER_ARRAY_MANAGER, Optional.empty());
@@ -86,17 +84,4 @@ public class IsEmptyFunctionTest extends AbstractFormulaTestCase
 		assertEquals("a", var.getName());
 		evaluatesTo(FormatUtilities.BOOLEAN_MANAGER, formula, node, Boolean.FALSE);
 	}
-
-	protected VariableID<Number[]> getArrayVariable(String formula)
-	{
-		VariableLibrary variableLibrary = getVariableLibrary();
-		ScopeInstance globalInst = getInstanceFactory().getGlobalInstance("Global");
-		variableLibrary.assertLegalVariableID(formula, globalInst.getLegalScope(),
-			TestUtilities.NUMBER_ARRAY_MANAGER);
-		@SuppressWarnings("unchecked")
-		VariableID<Number[]> variableID =
-				(VariableID<Number[]>) variableLibrary.getVariableID(globalInst, formula);
-		return variableID;
-	}
-
 }

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/IsPresentFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/IsPresentFunctionTest.java
@@ -20,14 +20,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import pcgen.base.formatmanager.FormatUtilities;
-import pcgen.base.formatmanager.OptionalFormatFactory;
-import pcgen.base.formatmanager.SimpleFormatManagerLibrary;
 import pcgen.base.formula.base.VariableID;
-import pcgen.base.formula.base.VariableLibrary;
 import pcgen.base.formula.parse.SimpleNode;
 import pcgen.base.testsupport.AbstractFormulaTestCase;
 import pcgen.base.testsupport.TestUtilities;
@@ -36,27 +31,12 @@ import pcgen.base.util.FormatManager;
 public class IsPresentFunctionTest extends AbstractFormulaTestCase
 {
 
-	SimpleFormatManagerLibrary library;
-	FormatManager<Optional<Number>> formatManager;
-
-	@SuppressWarnings("unchecked")
-	@Override
-	@BeforeEach
-	protected void setUp()
-	{
-		super.setUp();
-		library = new SimpleFormatManagerLibrary();
-		FormatUtilities.loadDefaultFormats(library);
-		FormatUtilities.loadDefaultFactories(library);
-		formatManager = (FormatManager<Optional<Number>>) new OptionalFormatFactory()
-			.build(Optional.empty(), Optional.of("NUMBER"), library);
-	}
-
 	@Test
 	public void testInvalidTooManyArg()
 	{
-		getVariableStore().put(getOptionalVariable("a"), Optional.of(3));
-		getVariableStore().put(getOptionalVariable("b"), Optional.of(3));
+		FormatManager<Optional<Number>> formatManager = getOptionalFormatManager();
+		setVariable(getOptionalVariable("a"), Optional.of(3));
+		setVariable(getOptionalVariable("b"), Optional.of(3));
 		String formula = "isPresent(a, b)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isNotValid(formula, node, formatManager, Optional.empty());
@@ -65,6 +45,7 @@ public class IsPresentFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testNotValidString()
 	{
+		FormatManager<Optional<Number>> formatManager = getOptionalFormatManager();
 		String formula = "isPresent(\"ab\")";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isNotValid(formula, node, formatManager, Optional.empty());
@@ -73,6 +54,7 @@ public class IsPresentFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testNotValidNoVar()
 	{
+		FormatManager<Optional<Number>> formatManager = getOptionalFormatManager();
 		String formula = "isPresent(ab)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isNotValid(formula, node, formatManager, Optional.empty());
@@ -81,7 +63,8 @@ public class IsPresentFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testVariable()
 	{
-		getVariableStore().put(getOptionalVariable("a"), Optional.of(3));
+		FormatManager<Optional<Number>> formatManager = getOptionalFormatManager();
+		setVariable(getOptionalVariable("a"), Optional.of(3));
 		String formula = "isPresent(a)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, formatManager, Optional.empty());
@@ -96,7 +79,8 @@ public class IsPresentFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testNullVariable()
 	{
-		getVariableStore().put(getOptionalVariable("a"), Optional.empty());
+		FormatManager<Optional<Number>> formatManager = getOptionalFormatManager();
+		setVariable(getOptionalVariable("a"), Optional.empty());
 		String formula = "isPresent(a)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, formatManager, Optional.empty());
@@ -107,17 +91,4 @@ public class IsPresentFunctionTest extends AbstractFormulaTestCase
 		assertEquals("a", var.getName());
 		evaluatesTo(formatManager, formula, node, Boolean.FALSE);
 	}
-
-	protected VariableID<Optional<Number>> getOptionalVariable(String formula)
-	{
-		VariableLibrary variableLibrary = getVariableLibrary();
-		variableLibrary.assertLegalVariableID(formula,
-			getInstanceFactory().getScope("Global"), formatManager);
-		@SuppressWarnings("unchecked")
-		VariableID<Optional<Number>> variableID =
-				(VariableID<Optional<Number>>) variableLibrary
-					.getVariableID(getGlobalScopeInst(), formula);
-		return variableID;
-	}
-
 }

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/LengthFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/LengthFunctionTest.java
@@ -61,12 +61,11 @@ public class LengthFunctionTest extends AbstractFormulaTestCase
 	public void testVariable()
 	{
 		VariableLibrary variableLibrary = getVariableLibrary();
-		variableLibrary.assertLegalVariableID("a",
-			getInstanceFactory().getScope("Global"), TestUtilities.NUMBER_ARRAY_MANAGER);
+		assertLegalVariable("a", "Global", TestUtilities.NUMBER_ARRAY_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number[]> variable = (VariableID<Number[]>) variableLibrary
 			.getVariableID(getGlobalScopeInst(), "a");
-		getVariableStore().put(variable, new Number[]{5});
+		setVariable(variable, new Number[]{5});
 		String formula = "length(a)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, TestUtilities.NUMBER_ARRAY_MANAGER, Optional.empty());
@@ -76,7 +75,7 @@ public class LengthFunctionTest extends AbstractFormulaTestCase
 		VariableID<?> var = vars.get(0);
 		assertEquals("a", var.getName());
 		evaluatesTo(FormatUtilities.NUMBER_MANAGER, formula, node, Double.valueOf(1));
-		getVariableStore().put(variable, new Number[]{5, 6, 7, 7, 8});
+		setVariable(variable, new Number[]{5, 6, 7, 7, 8});
 		evaluatesTo(FormatUtilities.NUMBER_MANAGER, formula, node, Double.valueOf(5));
 	}
 }

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/MaxFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/MaxFunctionTest.java
@@ -177,7 +177,7 @@ public class MaxFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testVar()
 	{
-		getVariableStore().put(getVariable("a"), 5);
+		setVariable(getVariable("a"), 5);
 		String formula = "max(4.6,a,-3.3)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
@@ -192,7 +192,7 @@ public class MaxFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testVariable()
 	{
-		getVariableStore().put(getVariable("a"), 5);
+		setVariable(getVariable("a"), 5);
 		String formula = "max(a, 3.4)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/MinFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/MinFunctionTest.java
@@ -167,7 +167,7 @@ public class MinFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testVariable()
 	{
-		getVariableStore().put(getVariable("a"), 5);
+		setVariable(getVariable("a"), 5);
 		String formula = "min(a, 7.4)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/RoundFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/RoundFunctionTest.java
@@ -170,7 +170,7 @@ public class RoundFunctionTest extends AbstractFormulaTestCase
 	@Test
 	public void testVariable()
 	{
-		getVariableStore().put(getVariable("a"), 5.3);
+		setVariable(getVariable("a"), 5.3);
 		String formula = "round(a)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/SliceFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/SliceFunctionTest.java
@@ -24,8 +24,6 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 import pcgen.base.formatmanager.FormatUtilities;
-import pcgen.base.formula.base.VariableID;
-import pcgen.base.formula.base.VariableLibrary;
 import pcgen.base.formula.parse.SimpleNode;
 import pcgen.base.formula.visitor.ReconstructionVisitor;
 import pcgen.base.testsupport.AbstractFormulaTestCase;
@@ -70,7 +68,7 @@ public class SliceFunctionTest extends AbstractFormulaTestCase
 	public void testSingleItem()
 	{
 		Number[] array = {1, 2, 3, 4, 5, 6, 7};
-		getVariableStore().put(getArray("ab"), array);
+		setVariable(getNumberArrayVar("ab"), array);
 		String formula = "slice(ab,1,2)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
@@ -85,7 +83,7 @@ public class SliceFunctionTest extends AbstractFormulaTestCase
 	public void testBoundedSlice()
 	{
 		Number[] array = {1, 2, 3, 4, 5, 6, 7};
-		getVariableStore().put(getArray("ab"), array);
+		setVariable(getNumberArrayVar("ab"), array);
 		String formula = "slice(ab,1,3)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
@@ -100,7 +98,7 @@ public class SliceFunctionTest extends AbstractFormulaTestCase
 	public void testUnboundedSlice()
 	{
 		Number[] array = {1, 2, 3, 4, 5, 6, 7};
-		getVariableStore().put(getArray("ab"), array);
+		setVariable(getNumberArrayVar("ab"), array);
 		String formula = "slice(ab,3)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
@@ -115,7 +113,7 @@ public class SliceFunctionTest extends AbstractFormulaTestCase
 	public void testNegativeStart()
 	{
 		Number[] array = {1, 2, 3, 4, 5, 6, 7};
-		getVariableStore().put(getArray("ab"), array);
+		setVariable(getNumberArrayVar("ab"), array);
 		String formula = "slice(ab,-3)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isNotValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
@@ -125,7 +123,7 @@ public class SliceFunctionTest extends AbstractFormulaTestCase
 	public void testInvalid()
 	{
 		Number[] array = {1, 2, 3, 4, 5, 6, 7};
-		getVariableStore().put(getArray("ab"), array);
+		setVariable(getNumberArrayVar("ab"), array);
 		String formula = "slice(ab,3,1)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isNotValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
@@ -135,7 +133,7 @@ public class SliceFunctionTest extends AbstractFormulaTestCase
 	public void testWastedEmpty()
 	{
 		Number[] array = {1, 2, 3, 4, 5, 6, 7};
-		getVariableStore().put(getArray("ab"), array);
+		setVariable(getNumberArrayVar("ab"), array);
 		String formula = "slice(ab,3,3)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isNotValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
@@ -145,7 +143,7 @@ public class SliceFunctionTest extends AbstractFormulaTestCase
 	public void testNonIntegerStart()
 	{
 		Number[] array = {1, 2, 3, 4, 5, 6, 7};
-		getVariableStore().put(getArray("ab"), array);
+		setVariable(getNumberArrayVar("ab"), array);
 		String formula = "slice(ab,3.1,1)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isNotValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
@@ -155,20 +153,9 @@ public class SliceFunctionTest extends AbstractFormulaTestCase
 	public void testNonIntegerEnd()
 	{
 		Number[] array = {1, 2, 3, 4, 5, 6, 7};
-		getVariableStore().put(getArray("ab"), array);
+		setVariable(getNumberArrayVar("ab"), array);
 		String formula = "slice(ab,3,1.2)";
 		SimpleNode node = TestUtilities.doParse(formula);
 		isNotValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
-	}
-
-	protected VariableID<Number[]> getArray(String formula)
-	{
-		VariableLibrary variableLibrary = getVariableLibrary();
-		variableLibrary.assertLegalVariableID(formula,
-			getInstanceFactory().getScope("Global"), TestUtilities.NUMBER_ARRAY_MANAGER);
-		@SuppressWarnings("unchecked")
-		VariableID<Number[]> variableID = (VariableID<Number[]>) variableLibrary
-			.getVariableID(getGlobalScopeInst(), formula);
-		return variableID;
 	}
 }

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/function/ValueFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/function/ValueFunctionTest.java
@@ -59,8 +59,8 @@ public class ValueFunctionTest extends AbstractFormulaTestCase
 		String formula = "value()";
 		SimpleNode node = TestUtilities.doParse(formula);
 		Optional<FormatManager<?>> assertedFormat = Optional.empty();
-		Objects.requireNonNull(assertedFormat);
 		//My isValid due to need to set INPUT_FORMAT
+		Objects.requireNonNull(assertedFormat);
 		SemanticsVisitor semanticsVisitor = new SemanticsVisitor();
 		FormulaSemantics semantics = getManagerFactory()
 			.generateFormulaSemantics(getFormulaManager(), getInstanceFactory().getScope("Global"));

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/ComplexNEPFormulaTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/ComplexNEPFormulaTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2016 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package pcgen.base.formula.inst;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -62,14 +79,14 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 			new ComplexNEPFormula<Number>("3*5", FormatUtilities.NUMBER_MANAGER).isValid(fs);
 			new ComplexNEPFormula<Number>("(3+5)*7", FormatUtilities.NUMBER_MANAGER).isValid(fs);
 			
-			getVariableLibrary().assertLegalVariableID("a", getInstanceFactory().getScope("Global"), FormatUtilities.NUMBER_MANAGER);
-			getVariableLibrary().assertLegalVariableID("b", getInstanceFactory().getScope("Global"), FormatUtilities.NUMBER_MANAGER);
+			assertLegalVariable("a", "Global", FormatUtilities.NUMBER_MANAGER);
+			assertLegalVariable("b", "Global", FormatUtilities.NUMBER_MANAGER);
 			new ComplexNEPFormula<Number>("a-b", FormatUtilities.NUMBER_MANAGER).isValid(fs);
 			new ComplexNEPFormula<Number>("if(a>=b,5,9)", FormatUtilities.NUMBER_MANAGER).isValid(fs);
 			new ComplexNEPFormula<Number>("if(a==b,5,-9)", FormatUtilities.NUMBER_MANAGER).isValid(fs);
 			
-			getVariableLibrary().assertLegalVariableID("c", getInstanceFactory().getScope("Global"), FormatUtilities.BOOLEAN_MANAGER);
-			getVariableLibrary().assertLegalVariableID("d", getInstanceFactory().getScope("Global"), FormatUtilities.BOOLEAN_MANAGER);
+			assertLegalVariable("c", "Global", FormatUtilities.BOOLEAN_MANAGER);
+			assertLegalVariable("d", "Global", FormatUtilities.BOOLEAN_MANAGER);
 			new ComplexNEPFormula<String>("if(c||d,\"A\",\"B\")", FormatUtilities.STRING_MANAGER).isValid(fs);
 			
 			new ComplexNEPFormula<Number>("value()", FormatUtilities.NUMBER_MANAGER).isValid(
@@ -124,10 +141,8 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 	@Test
 	public void testGetDependenciesVars()
 	{
-		getVariableLibrary().assertLegalVariableID("a",
-			getInstanceFactory().getScope("Global"), FormatUtilities.NUMBER_MANAGER);
-		getVariableLibrary().assertLegalVariableID("b",
-			getInstanceFactory().getScope("Global"), FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("a", "Global", FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("b", "Global", FormatUtilities.NUMBER_MANAGER);
 
 		DependencyManager depManager = setupDM();
 		Optional<VariableList> potentialVariables =
@@ -137,20 +152,17 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 		new ComplexNEPFormula<>("a-b", FormatUtilities.NUMBER_MANAGER).getDependencies(depManager);
 		List<VariableID<?>> variables = potentialVariables.get().getVariables();
 		assertEquals(2, variables.size());
-		assertTrue(
-			variables.contains(new VariableID<>(getGlobalScopeInst(), FormatUtilities.NUMBER_MANAGER, "a")));
-		assertTrue(
-			variables.contains(new VariableID<>(getGlobalScopeInst(), FormatUtilities.NUMBER_MANAGER, "b")));
+		//Validate equality by constructing our own VariableIDs
+		assertTrue(variables.contains(getVariable("a")));
+		assertTrue(variables.contains(getVariable("b")));
 		assertEquals(-1, potentialArgDM.get().getMaximumArgument());
 	}
 
 	@Test
 	public void testGetDependenciesVarsIfOne()
 	{
-		getVariableLibrary().assertLegalVariableID("a",
-			getInstanceFactory().getScope("Global"), FormatUtilities.NUMBER_MANAGER);
-		getVariableLibrary().assertLegalVariableID("b",
-			getInstanceFactory().getScope("Global"), FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("a", "Global", FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("b", "Global", FormatUtilities.NUMBER_MANAGER);
 		DependencyManager depManager = setupDM();
 		Optional<VariableList> potentialVariables =
 				depManager.get(DependencyManager.VARIABLES);
@@ -159,20 +171,16 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 		new ComplexNEPFormula<>("if(a>=b,5,9)", FormatUtilities.NUMBER_MANAGER).getDependencies(depManager);
 		List<VariableID<?>> variables = potentialVariables.get().getVariables();
 		assertEquals(2, variables.size());
-		assertTrue(
-			variables.contains(new VariableID<>(getGlobalScopeInst(), FormatUtilities.NUMBER_MANAGER, "a")));
-		assertTrue(
-			variables.contains(new VariableID<>(getGlobalScopeInst(), FormatUtilities.NUMBER_MANAGER, "b")));
+		assertTrue(variables.contains(getVariable("a")));
+		assertTrue(variables.contains(getVariable("b")));
 		assertEquals(-1, potentialArgDM.get().getMaximumArgument());
 	}
 
 	@Test
 	public void testGetDependenciesVarsIfTwo()
 	{
-		getVariableLibrary().assertLegalVariableID("a",
-			getInstanceFactory().getScope("Global"), FormatUtilities.NUMBER_MANAGER);
-		getVariableLibrary().assertLegalVariableID("b",
-			getInstanceFactory().getScope("Global"), FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("a", "Global", FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("b", "Global", FormatUtilities.NUMBER_MANAGER);
 		DependencyManager depManager = setupDM();
 		Optional<VariableList> potentialVariables =
 				depManager.get(DependencyManager.VARIABLES);
@@ -181,20 +189,16 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 		new ComplexNEPFormula<>("if(a==b,5,-9)", FormatUtilities.NUMBER_MANAGER).getDependencies(depManager);
 		List<VariableID<?>> variables = potentialVariables.get().getVariables();
 		assertEquals(2, variables.size());
-		assertTrue(
-			variables.contains(new VariableID<>(getGlobalScopeInst(), FormatUtilities.NUMBER_MANAGER, "a")));
-		assertTrue(
-			variables.contains(new VariableID<>(getGlobalScopeInst(), FormatUtilities.NUMBER_MANAGER, "b")));
+		assertTrue(variables.contains(getVariable("a")));
+		assertTrue(variables.contains(getVariable("b")));
 		assertEquals(-1, potentialArgDM.get().getMaximumArgument());
 	}
 
 	@Test
 	public void testGetDependenciesVarsIfThree()
 	{
-		getVariableLibrary().assertLegalVariableID("c",
-			getInstanceFactory().getScope("Global"), FormatUtilities.BOOLEAN_MANAGER);
-		getVariableLibrary().assertLegalVariableID("d",
-			getInstanceFactory().getScope("Global"), FormatUtilities.BOOLEAN_MANAGER);
+		assertLegalVariable("c", "Global", FormatUtilities.BOOLEAN_MANAGER);
+		assertLegalVariable("d", "Global", FormatUtilities.BOOLEAN_MANAGER);
 
 		DependencyManager depManager = setupDM();
 		Optional<VariableList> potentialVariables =
@@ -205,10 +209,8 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 			.getDependencies(depManager);
 		List<VariableID<?>> variables = potentialVariables.get().getVariables();
 		assertEquals(2, variables.size());
-		assertTrue(
-			variables.contains(new VariableID<>(getGlobalScopeInst(), FormatUtilities.BOOLEAN_MANAGER, "c")));
-		assertTrue(
-			variables.contains(new VariableID<>(getGlobalScopeInst(), FormatUtilities.BOOLEAN_MANAGER, "d")));
+		assertTrue(variables.contains(getBooleanVariable("c")));
+		assertTrue(variables.contains(getBooleanVariable("d")));
 		assertEquals(-1, potentialArgDM.get().getMaximumArgument());
 	}
 
@@ -245,11 +247,11 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 		assertEquals(56,
 			new ComplexNEPFormula<>("(3+5)*7", FormatUtilities.NUMBER_MANAGER).resolve(evalManager));
 
-		getVariableLibrary().assertLegalVariableID("a", getInstanceFactory().getScope("Global"), FormatUtilities.NUMBER_MANAGER);
-		getVariableLibrary().assertLegalVariableID("b", getInstanceFactory().getScope("Global"), FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("a", "Global", FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("b", "Global", FormatUtilities.NUMBER_MANAGER);
 
-		getVariableStore().put(new VariableID<>(getGlobalScopeInst(), FormatUtilities.NUMBER_MANAGER, "a"), 4);
-		getVariableStore().put(new VariableID<>(getGlobalScopeInst(), FormatUtilities.NUMBER_MANAGER, "b"), 1);
+		setVariable(getVariable("a"), 4);
+		setVariable(getVariable("b"), 1);
 		assertEquals(3, new ComplexNEPFormula<>("a-b", FormatUtilities.NUMBER_MANAGER).resolve(evalManager));
 
 		assertEquals(5,
@@ -258,12 +260,10 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 		assertEquals(-9,
 			new ComplexNEPFormula<>("if(a==b,5,-9)", FormatUtilities.NUMBER_MANAGER).resolve(evalManager));
 
-		getVariableLibrary().assertLegalVariableID("c", getInstanceFactory().getScope("Global"), FormatUtilities.BOOLEAN_MANAGER);
-		getVariableLibrary().assertLegalVariableID("d", getInstanceFactory().getScope("Global"), FormatUtilities.BOOLEAN_MANAGER);
-		getVariableStore().put(new VariableID<>(getGlobalScopeInst(), FormatUtilities.BOOLEAN_MANAGER, "c"),
-			false);
-		getVariableStore().put(new VariableID<>(getGlobalScopeInst(), FormatUtilities.BOOLEAN_MANAGER, "d"),
-			true);
+		assertLegalVariable("c", "Global", FormatUtilities.BOOLEAN_MANAGER);
+		assertLegalVariable("d", "Global", FormatUtilities.BOOLEAN_MANAGER);
+		setVariable(getBooleanVariable("c"), false);
+		setVariable(getBooleanVariable("d"), true);
 
 		assertEquals("A",
 			new ComplexNEPFormula<>("if(c||d,\"A\",\"B\")", FormatUtilities.NUMBER_MANAGER).resolve(evalManager));

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/ScopeManagerInstTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/ScopeManagerInstTest.java
@@ -25,8 +25,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import pcgen.base.formula.base.LegalScope;
@@ -34,32 +32,21 @@ import pcgen.base.formula.base.LegalScope;
 public class ScopeManagerInstTest
 {
 
-	private ScopeManagerInst legalScopeManager;
 	private SimpleLegalScope globalScope = new SimpleLegalScope("Global");
 	private SimpleLegalScope subScope = new SimpleLegalScope(globalScope, "SubScope");
 	private SimpleLegalScope otherScope = new SimpleLegalScope(globalScope, "OtherScope");
 
-	@BeforeEach
-	void setUp()
-	{
-		legalScopeManager = new ScopeManagerInst();
-	}
-	
-	@AfterEach
-	void tearDown()
-	{
-		legalScopeManager = null;
-	}
-
 	@Test
 	public void testNullRegister()
 	{
+		ScopeManagerInst legalScopeManager = new ScopeManagerInst();
 		assertThrows(NullPointerException.class, () -> legalScopeManager.registerScope(null));
 	}
 
 	@Test
 	public void testBadRegister()
 	{
+		ScopeManagerInst legalScopeManager = new ScopeManagerInst();
 		assertThrows(NullPointerException.class, () -> legalScopeManager.registerScope(new BadLegalScope1()));
 		assertThrows(NullPointerException.class, () -> legalScopeManager.registerScope(new BadLegalScope2()));
 		assertThrows(IllegalArgumentException.class, () -> legalScopeManager.registerScope(subScope));
@@ -72,6 +59,7 @@ public class ScopeManagerInstTest
 	@Test
 	public void testDupeOkay()
 	{
+		ScopeManagerInst legalScopeManager = new ScopeManagerInst();
 		legalScopeManager.registerScope(globalScope);
 		legalScopeManager.registerScope(subScope);
 		//This is okay
@@ -81,12 +69,14 @@ public class ScopeManagerInstTest
 	@Test
 	public void testNullGet()
 	{
+		ScopeManagerInst legalScopeManager = new ScopeManagerInst();
 		assertThrows(NullPointerException.class, () -> legalScopeManager.getChildScopes(null));
 	}
 
 	@Test
 	public void testGetScope()
 	{
+		ScopeManagerInst legalScopeManager = new ScopeManagerInst();
 		List<LegalScope> children = legalScopeManager.getChildScopes(globalScope);
 		if (children != null)
 		{
@@ -104,6 +94,7 @@ public class ScopeManagerInstTest
 	@Test
 	public void testGetChildScopes()
 	{
+		ScopeManagerInst legalScopeManager = new ScopeManagerInst();
 		List<LegalScope> children = legalScopeManager.getChildScopes(globalScope);
 		if (children != null)
 		{
@@ -136,6 +127,7 @@ public class ScopeManagerInstTest
 	@Test
 	public void testGetLegalScopes()
 	{
+		ScopeManagerInst legalScopeManager = new ScopeManagerInst();
 		Collection<LegalScope> legal = legalScopeManager.getLegalScopes();
 		assertEquals(0, legal.size());
 		legalScopeManager.registerScope(globalScope);

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleScopeInstanceTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleScopeInstanceTest.java
@@ -22,39 +22,21 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Optional;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class SimpleScopeInstanceTest
 {
 
-	private SimpleLegalScope scope;
-	private SimpleScopeInstance scopeInst;
-	private SimpleLegalScope local;
-	private SimpleScopeInstance localInst;
-	
-	@BeforeEach
-	void setUp()
-	{
-		scope = new SimpleLegalScope("Global");
-		scopeInst = new SimpleScopeInstance(Optional.empty(), scope, new GlobalVarScoped("Global"));
-		local = new SimpleLegalScope(scope, "Local");
-		localInst = new SimpleScopeInstance(Optional.of(scopeInst), local, new GlobalVarScoped("Local"));
-	}
-	
-	@AfterEach
-	void tearDown()
-	{
-		scope = null;
-		scopeInst = null;
-		local = null;
-		localInst = null;
-	}
-
 	@Test
 	public void testConstructor()
 	{
+		SimpleLegalScope scope = new SimpleLegalScope("Global");
+		SimpleScopeInstance scopeInst = new SimpleScopeInstance(
+			Optional.empty(), scope, new GlobalVarScoped("Global"));
+		SimpleLegalScope local = new SimpleLegalScope(scope, "Local");
+		SimpleScopeInstance localInst = new SimpleScopeInstance(
+			Optional.of(scopeInst), local, new GlobalVarScoped("Local"));
+
 		assertThrows(NullPointerException.class, () -> new SimpleScopeInstance(Optional.of(scopeInst), null, new GlobalVarScoped("Global")));
 		assertThrows(IllegalArgumentException.class, () -> new SimpleScopeInstance(Optional.of(scopeInst), scope, new GlobalVarScoped("Ignored")));
 		assertThrows(IllegalArgumentException.class, () -> new SimpleScopeInstance(Optional.of(localInst), local, new GlobalVarScoped("Ignored")));
@@ -73,6 +55,13 @@ public class SimpleScopeInstanceTest
 	@Test
 	public void testIsValid()
 	{
+		SimpleLegalScope scope = new SimpleLegalScope("Global");
+		SimpleScopeInstance scopeInst = new SimpleScopeInstance(
+			Optional.empty(), scope, new GlobalVarScoped("Global"));
+		SimpleLegalScope local = new SimpleLegalScope(scope, "Local");
+		SimpleScopeInstance localInst = new SimpleScopeInstance(
+			Optional.of(scopeInst), local, new GlobalVarScoped("Local"));
+
 		assertEquals(local, localInst.getLegalScope());
 		assertEquals(scopeInst, localInst.getParentScope().get());
 	}

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleVariableStoreTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleVariableStoreTest.java
@@ -23,11 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import pcgen.base.format.NumberManager;
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.ScopeInstance;
 import pcgen.base.formula.base.ScopeInstanceFactory;
@@ -35,32 +32,16 @@ import pcgen.base.formula.base.VariableID;
 
 public class SimpleVariableStoreTest
 {
-
-	private ScopeManagerInst legalScopeManager;
-	private ScopeInstanceFactory instanceFactory;
-		
-	@BeforeEach
-	void setUp()
-	{
-		legalScopeManager = new ScopeManagerInst();
-		legalScopeManager.registerScope(new SimpleLegalScope("Global"));
-		instanceFactory = new SimpleScopeInstanceFactory(legalScopeManager);
-	}
-	
-	@AfterEach
-	void tearDown()
-	{
-		legalScopeManager = null;
-		instanceFactory = null;
-	}
-
 	@Test
 	public void testNulls()
 	{
+		ScopeManagerInst legalScopeManager = new ScopeManagerInst();
+		legalScopeManager.registerScope(new SimpleLegalScope("Global"));
+		ScopeInstanceFactory instanceFactory =
+				new SimpleScopeInstanceFactory(legalScopeManager);
 		SimpleVariableStore varStore = new SimpleVariableStore();
-		NumberManager numberManager = new NumberManager();
 		ScopeInstance globalInst = instanceFactory.getGlobalInstance("Global");
-		VariableID<Number> vid = new VariableID<>(globalInst, numberManager, "test");
+		VariableID<Number> vid = new VariableID<>(globalInst, FormatUtilities.NUMBER_MANAGER, "test");
 		assertThrows(NullPointerException.class, () -> varStore.put(null, Integer.valueOf(4)));
 		assertThrows(NullPointerException.class, () -> varStore.put(vid, null));
 	}
@@ -69,10 +50,13 @@ public class SimpleVariableStoreTest
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	public void testGenericsViolation()
 	{
+		ScopeManagerInst legalScopeManager = new ScopeManagerInst();
+		legalScopeManager.registerScope(new SimpleLegalScope("Global"));
+		ScopeInstanceFactory instanceFactory =
+				new SimpleScopeInstanceFactory(legalScopeManager);
 		SimpleVariableStore varStore = new SimpleVariableStore();
-		NumberManager numberManager = new NumberManager();
 		ScopeInstance globalInst = instanceFactory.getGlobalInstance("Global");
-		VariableID vid = new VariableID<>(globalInst, numberManager, "test");
+		VariableID vid = new VariableID<>(globalInst, FormatUtilities.NUMBER_MANAGER, "test");
 		//Intentionally break generics
 		assertThrows(IllegalArgumentException.class, () -> varStore.put(vid, "NotANumber!"));
 	}
@@ -80,10 +64,13 @@ public class SimpleVariableStoreTest
 	@Test
 	public void testGlobal()
 	{
+		ScopeManagerInst legalScopeManager = new ScopeManagerInst();
+		legalScopeManager.registerScope(new SimpleLegalScope("Global"));
+		ScopeInstanceFactory instanceFactory =
+				new SimpleScopeInstanceFactory(legalScopeManager);
 		SimpleVariableStore varStore = new SimpleVariableStore();
-		NumberManager numberManager = FormatUtilities.NUMBER_MANAGER;
 		ScopeInstance globalInst = instanceFactory.getGlobalInstance("Global");
-		VariableID<Number> vid = new VariableID<>(globalInst, numberManager, "test");
+		VariableID<Number> vid = new VariableID<>(globalInst, FormatUtilities.NUMBER_MANAGER, "test");
 		assertFalse(varStore.containsKey(vid));
 		assertNull(varStore.put(vid, Integer.valueOf(9)));
 		assertTrue(varStore.containsKey(vid));
@@ -96,15 +83,18 @@ public class SimpleVariableStoreTest
 	@Test
 	public void testIndependence()
 	{
+		ScopeManagerInst legalScopeManager = new ScopeManagerInst();
+		legalScopeManager.registerScope(new SimpleLegalScope("Global"));
+		ScopeInstanceFactory instanceFactory =
+				new SimpleScopeInstanceFactory(legalScopeManager);
 		SimpleVariableStore varStore = new SimpleVariableStore();
-		NumberManager numberManager = new NumberManager();
 		ScopeInstance globalInst = instanceFactory.getGlobalInstance("Global");
-		VariableID<Number> vid1 = new VariableID<>(globalInst, numberManager, "test");
-		VariableID<Number> vid2 = new VariableID<>(globalInst, numberManager, "test");
-		VariableID<Number> vid3 = new VariableID<>(globalInst, numberManager, "test2");
+		VariableID<Number> vid1 = new VariableID<>(globalInst, FormatUtilities.NUMBER_MANAGER, "test");
+		VariableID<Number> vid2 = new VariableID<>(globalInst, FormatUtilities.NUMBER_MANAGER, "test");
+		VariableID<Number> vid3 = new VariableID<>(globalInst, FormatUtilities.NUMBER_MANAGER, "test2");
 		legalScopeManager.registerScope(new SimpleLegalScope("Global2"));
 		ScopeInstance globalInst2 = instanceFactory.getGlobalInstance("Global2");
-		VariableID<Number> vid4 = new VariableID<>(globalInst2, numberManager, "test");
+		VariableID<Number> vid4 = new VariableID<>(globalInst2, FormatUtilities.NUMBER_MANAGER, "test");
 		assertNull(varStore.put(vid1, Integer.valueOf(9)));
 		assertTrue(varStore.containsKey(vid1));
 		assertTrue(varStore.containsKey(vid2));

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/library/GenericFunctionTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/library/GenericFunctionTest.java
@@ -94,7 +94,6 @@ public class GenericFunctionTest extends AbstractFormulaTestCase
 	{
 		String formula2 = "floor((14-10)/2)";
 		SimpleNode node2 = TestUtilities.doParse(formula2);
-		getFunctionLibrary().addFunction(new GenericFunction("noargs", node2));
 		isValid(formula2, node2, FormatUtilities.NUMBER_MANAGER, Optional.empty());
 		String formula = "noargs(2)";
 		SimpleNode node = TestUtilities.doParse(formula);

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/parse/FormulaVariableTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/parse/FormulaVariableTest.java
@@ -23,57 +23,21 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import pcgen.base.formatmanager.FormatUtilities;
-import pcgen.base.formula.base.OperatorLibrary;
 import pcgen.base.formula.base.VariableID;
-import pcgen.base.formula.base.WriteableVariableStore;
-import pcgen.base.formula.operator.bool.BooleanNot;
-import pcgen.base.formula.operator.number.NumberAdd;
-import pcgen.base.formula.operator.number.NumberDivide;
-import pcgen.base.formula.operator.number.NumberEquals;
-import pcgen.base.formula.operator.number.NumberMultiply;
-import pcgen.base.formula.operator.number.NumberSubtract;
 import pcgen.base.formula.visitor.ReconstructionVisitor;
 import pcgen.base.testsupport.AbstractFormulaTestCase;
 import pcgen.base.testsupport.TestUtilities;
 
 public class FormulaVariableTest extends AbstractFormulaTestCase
 {
-
-	private WriteableVariableStore store;
-
-	@BeforeEach
-	@Override
-	protected void setUp()
-	{
-		super.setUp();
-		store = getVariableStore();
-		OperatorLibrary operatorLibrary = getOperatorLibrary();
-		operatorLibrary.addAction(new NumberEquals());
-		operatorLibrary.addAction(new NumberAdd());
-		operatorLibrary.addAction(new BooleanNot());
-		operatorLibrary.addAction(new NumberSubtract());
-		operatorLibrary.addAction(new NumberDivide());
-		operatorLibrary.addAction(new NumberMultiply());
-	}
-	
-	@AfterEach
-	@Override
-	protected void tearDown()
-	{
-		super.tearDown();
-		store = null;
-	}
-
 	@Test
 	public void testSimpleVariablePositive()
 	{
 		String formula = "a";
-		store.put(getVariable(formula), 5);
+		setVariable(getVariable(formula), 5);
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
 		isStatic(formula, node, false);
@@ -92,7 +56,7 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 	public void testSimpleVariableNegative()
 	{
 		String formula = "a";
-		store.put(getVariable(formula), -7);
+		setVariable(getVariable(formula), -7);
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
 		isStatic(formula, node, false);
@@ -111,7 +75,7 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 	public void testSimpleVariableDouble()
 	{
 		String formula = "a";
-		store.put(getVariable(formula), -7.3);
+		setVariable(getVariable(formula), -7.3);
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
 		isStatic(formula, node, false);
@@ -130,8 +94,8 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 	public void testAddVariableVariable()
 	{
 		String formula = "a+b";
-		store.put(getVariable("a"), 3);
-		store.put(getVariable("b"), 7);
+		setVariable(getVariable("a"), 3);
+		setVariable(getVariable("b"), 7);
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
 		isStatic(formula, node, false);
@@ -147,8 +111,8 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 	public void testAddVariableVariableDouble()
 	{
 		String formula = "a+b";
-		store.put(getVariable("a"), 3.2);
-		store.put(getVariable("b"), -7.9);
+		setVariable(getVariable("a"), 3.2);
+		setVariable(getVariable("b"), -7.9);
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
 		isStatic(formula, node, false);
@@ -164,9 +128,9 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 	public void testAddMultiple()
 	{
 		String formula = "a+b+c";
-		store.put(getVariable("a"), 3.2);
-		store.put(getVariable("b"), -7.9);
-		store.put(getVariable("c"), 2.2);
+		setVariable(getVariable("a"), 3.2);
+		setVariable(getVariable("b"), -7.9);
+		setVariable(getVariable("c"), 2.2);
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
 		isStatic(formula, node, false);
@@ -182,7 +146,7 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 	public void testSubtractInteger()
 	{
 		String formula = "a-3";
-		store.put(getVariable("a"), 3.2);
+		setVariable(getVariable("a"), 3.2);
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
 		isStatic(formula, node, false);
@@ -202,8 +166,8 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 	public void testSubtractVariableVariable()
 	{
 		String formula = "a-b";
-		store.put(getVariable("a"), 3.2);
-		store.put(getVariable("b"), 2.1);
+		setVariable(getVariable("a"), 3.2);
+		setVariable(getVariable("b"), 2.1);
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
 		isStatic(formula, node, false);
@@ -219,8 +183,8 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 	public void testEqualVariableDifferentVariable()
 	{
 		String formula = "a==b";
-		store.put(getVariable("a"), 3.2);
-		store.put(getVariable("b"), 2.1);
+		setVariable(getVariable("a"), 3.2);
+		setVariable(getVariable("b"), 2.1);
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, false);
@@ -236,8 +200,8 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 	public void testEqualVariableDifferentType()
 	{
 		String formula = "a==b";
-		store.put(getVariable("a"), 3.2);
-		getVariableStore().put(getBooleanVariable("b"), false);
+		setVariable(getVariable("a"), 3.2);
+		setVariable(getBooleanVariable("b"), false);
 		SimpleNode node = TestUtilities.doParse(formula);
 		isNotValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
 		isNotValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
@@ -247,8 +211,8 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 	public void testEqualZeroVariableZeroVariable()
 	{
 		String formula = "a==b";
-		store.put(getVariable("a"), 0.0);
-		store.put(getVariable("b"), 0);
+		setVariable(getVariable("a"), 0.0);
+		setVariable(getVariable("b"), 0);
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, false);
@@ -264,8 +228,8 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 	public void testEqualVariableEqualVariable()
 	{
 		String formula = "a==b";
-		store.put(getVariable("a"), -2.1);
-		store.put(getVariable("b"), -2.1);
+		setVariable(getVariable("a"), -2.1);
+		setVariable(getVariable("b"), -2.1);
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, false);
@@ -291,9 +255,9 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 	public void testParens()
 	{
 		String formula = "a*(b+c)";
-		store.put(getVariable("a"), 2);
-		store.put(getVariable("b"), 1.2);
-		store.put(getVariable("c"), -0.3);
+		setVariable(getVariable("a"), 2);
+		setVariable(getVariable("b"), 1.2);
+		setVariable(getVariable("c"), -0.3);
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
 		isStatic(formula, node, false);
@@ -308,9 +272,9 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 	public void testExtraParens()
 	{
 		String formula = "((a/(((b-c)))))";
-		store.put(getVariable("a"), 3);
-		store.put(getVariable("b"), 1.2);
-		store.put(getVariable("c"), -0.3);
+		setVariable(getVariable("a"), 3);
+		setVariable(getVariable("b"), 1.2);
+		setVariable(getVariable("c"), -0.3);
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.NUMBER_MANAGER, Optional.empty());
 		isStatic(formula, node, false);
@@ -401,7 +365,7 @@ public class FormulaVariableTest extends AbstractFormulaTestCase
 	public void testBooleanNegation()
 	{
 		String formula = "!a";
-		store.put(getBooleanVariable("a"), Boolean.FALSE);
+		setVariable(getBooleanVariable("a"), Boolean.FALSE);
 		SimpleNode node = TestUtilities.doParse(formula);
 		isValid(formula, node, FormatUtilities.BOOLEAN_MANAGER, Optional.empty());
 		isStatic(formula, node, false);

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/AggressiveSolverManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/AggressiveSolverManagerTest.java
@@ -71,8 +71,7 @@ public class AggressiveSolverManagerTest extends AbstractSolverManagerTest
 	@Test
 	public void testTrivial()
 	{
-		getVariableLibrary().assertLegalVariableID("Limbs",
-			getInstanceFactory().getScope("Global"), FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("Limbs", "Global", FormatUtilities.NUMBER_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number> limbs = (VariableID<Number>) getVariableLibrary()
 			.getVariableID(getGlobalScopeInst(), "Limbs");
@@ -91,8 +90,7 @@ public class AggressiveSolverManagerTest extends AbstractSolverManagerTest
 		WriteableVariableStore store = getVariableStore();
 		LegalScope globalScope = getInstanceFactory().getScope("Global");
 		ScopeInstance globalScopeInst = getGlobalScopeInst();
-		getVariableLibrary().assertLegalVariableID("STR", globalScope,
-			FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("STR", "Global", FormatUtilities.NUMBER_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number> str =
 				(VariableID<Number>) getVariableLibrary().getVariableID(globalScopeInst,
@@ -108,8 +106,7 @@ public class AggressiveSolverManagerTest extends AbstractSolverManagerTest
 		ScopeInstance strInst =
 				getInstanceFactory().get("Global.STAT", Optional.of(new MockStat("Strength")));
 
-		getVariableLibrary().assertLegalVariableID("Mod", localScope,
-			FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("Mod", "Global.STAT", FormatUtilities.NUMBER_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number> mod =
 				(VariableID<Number>) getVariableLibrary().getVariableID(strInst, "Mod");

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/DynamicSolverManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/DynamicSolverManagerTest.java
@@ -58,7 +58,6 @@ import pcgen.base.util.Indirect;
 public class DynamicSolverManagerTest extends AbstractSolverManagerTest
 {
 	private DynamicSolverManager manager;
-	private LimbManager limbManager;
 
 	@BeforeEach
 	@Override
@@ -67,9 +66,6 @@ public class DynamicSolverManagerTest extends AbstractSolverManagerTest
 		super.setUp();
 		manager = new DynamicSolverManager(getFormulaManager(), TestUtilities.EMPTY_MGR_FACTORY,
 			getSolverFactory(), getVariableStore());
-		limbManager = new LimbManager();
-		getValueStore().addSolverFormat(limbManager,
-			() -> limbManager.convert("Head"));
 	}
 	
 	@AfterEach
@@ -78,7 +74,6 @@ public class DynamicSolverManagerTest extends AbstractSolverManagerTest
 	{
 		super.tearDown();
 		manager = null;
-		limbManager = null;
 	}
 
 	@Test
@@ -108,21 +103,25 @@ public class DynamicSolverManagerTest extends AbstractSolverManagerTest
 		getFunctionLibrary().addFunction(new Dynamic());
 		LegalScope globalScope = getInstanceFactory().getScope("Global");
 
+		LimbManager limbManager = new LimbManager();
+		getValueStore().addSolverFormat(limbManager,
+			() -> limbManager.convert("Head"));
+
 		SimpleLegalScope limbScope = new SimpleLegalScope(globalScope, "LIMB");
 		getScopeManager().registerScope(limbScope);
-		getVarLibrary().assertLegalVariableID("active", globalScope, limbManager);
-		getVarLibrary().assertLegalVariableID("quantity", limbScope, FormatUtilities.NUMBER_MANAGER);
-		getVarLibrary().assertLegalVariableID("result", globalScope, FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("active", "Global", limbManager);
+		assertLegalVariable("quantity", "Global.LIMB", FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("result", "Global", FormatUtilities.NUMBER_MANAGER);
 
 		ComplexNEPFormula<Number> dynamicformula =
 				new ComplexNEPFormula<Number>("dynamic(active, quantity)", FormatUtilities.NUMBER_MANAGER);
 		Modifier<Number> dynamicMod = AbstractModifier.add(dynamicformula, 100);
 
 		@SuppressWarnings("unchecked")
-		VariableID<Limb> active = (VariableID<Limb>) getVarLibrary()
+		VariableID<Limb> active = (VariableID<Limb>) getVariableLibrary()
 			.getVariableID(getGlobalScopeInst(), "Active");
 		@SuppressWarnings("unchecked")
-		VariableID<Number> result = (VariableID<Number>) getVarLibrary()
+		VariableID<Number> result = (VariableID<Number>) getVariableLibrary()
 			.getVariableID(getGlobalScopeInst(), "Result");
 
 		Limb hands = limbManager.convert("Hands");
@@ -132,9 +131,9 @@ public class DynamicSolverManagerTest extends AbstractSolverManagerTest
 
 		@SuppressWarnings("unchecked")
 		VariableID<Number> handsID =
-				(VariableID<Number>) getVarLibrary().getVariableID(handsInst, "Quantity");
+				(VariableID<Number>) getVariableLibrary().getVariableID(handsInst, "Quantity");
 		@SuppressWarnings("unchecked")
-		VariableID<Number> fingersID = (VariableID<Number>) getVarLibrary()
+		VariableID<Number> fingersID = (VariableID<Number>) getVariableLibrary()
 			.getVariableID(fingersInst, "Quantity");
 
 		AbstractModifier<Number> two = AbstractModifier.setNumber(2, 5);
@@ -167,8 +166,7 @@ public class DynamicSolverManagerTest extends AbstractSolverManagerTest
 	@Test
 	public void testTrivial()
 	{
-		getVariableLibrary().assertLegalVariableID("Limbs",
-			getInstanceFactory().getScope("Global"), FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("Limbs", "Global", FormatUtilities.NUMBER_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number> limbs = (VariableID<Number>) getVariableLibrary()
 			.getVariableID(getGlobalScopeInst(), "Limbs");
@@ -330,23 +328,27 @@ public class DynamicSolverManagerTest extends AbstractSolverManagerTest
 	@Test
 	public void testAnother()
 	{
+		LimbManager limbManager = new LimbManager();
+		getValueStore().addSolverFormat(limbManager,
+			() -> limbManager.convert("Head"));
+
 		ScopeInstance source = getGlobalScopeInst();
 		LegalScope globalScope = getInstanceFactory().getScope("Global");
 
 		SimpleLegalScope limbScope = new SimpleLegalScope(globalScope, "LIMB");
 		getScopeManager().registerScope(limbScope);
 
-		getVarLibrary().assertLegalVariableID("LocalVar", limbScope, FormatUtilities.NUMBER_MANAGER);
-		getVarLibrary().assertLegalVariableID("ResultVar", globalScope, FormatUtilities.NUMBER_MANAGER);
-		getVarLibrary().assertLegalVariableID("EquipVar", globalScope, limbManager);
+		assertLegalVariable("LocalVar", "Global.LIMB", FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("ResultVar", "Global", FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("EquipVar", "Global", limbManager);
 
 		WriteableVariableStore store = getVariableStore();
 
 		@SuppressWarnings("unchecked")
-		VariableID<Limb> activeID = (VariableID<Limb>) getVarLibrary()
+		VariableID<Limb> activeID = (VariableID<Limb>) getVariableLibrary()
 			.getVariableID(getGlobalScopeInst(), "EquipVar");
 		@SuppressWarnings("unchecked")
-		VariableID<Number> resultID = (VariableID<Number>) getVarLibrary()
+		VariableID<Number> resultID = (VariableID<Number>) getVariableLibrary()
 			.getVariableID(getGlobalScopeInst(), "ResultVar");
 
 		Limb equip = limbManager.convert("EquipKey");
@@ -356,10 +358,10 @@ public class DynamicSolverManagerTest extends AbstractSolverManagerTest
 
 		@SuppressWarnings("unchecked")
 		VariableID<Number> equipID =
-				(VariableID<Number>) getVarLibrary().getVariableID(equipInst, "LocalVar");
+				(VariableID<Number>) getVariableLibrary().getVariableID(equipInst, "LocalVar");
 		@SuppressWarnings("unchecked")
 		VariableID<Number> altID =
-				(VariableID<Number>) getVarLibrary().getVariableID(altInst, "LocalVar");
+				(VariableID<Number>) getVariableLibrary().getVariableID(altInst, "LocalVar");
 
 		AbstractModifier<Number> two = AbstractModifier.setNumber(2, 5);
 		AbstractModifier<Number> three = AbstractModifier.setNumber(3, 10);

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/testsupport/AbstractSolverManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/testsupport/AbstractSolverManagerTest.java
@@ -79,16 +79,14 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 	@Test
 	public void testIllegalCreateChannel()
 	{
-		varLibrary.assertLegalVariableID("HP", globalScope,
-			FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("HP", "Global", FormatUtilities.NUMBER_MANAGER);
 		assertThrows(NullPointerException.class, () -> getManager().createChannel(null));
 	}
 
 	@Test
 	public void testCreateChannelTwice()
 	{
-		varLibrary.assertLegalVariableID("HP", globalScope,
-			FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("HP", "Global", FormatUtilities.NUMBER_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number> hp =
 				(VariableID<Number>) varLibrary.getVariableID(globalScopeInst, "HP");
@@ -99,8 +97,7 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 	@Test
 	public void testCreateChannel()
 	{
-		varLibrary.assertLegalVariableID("HP", globalScope,
-			FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("HP", "Global", FormatUtilities.NUMBER_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number> hp =
 				(VariableID<Number>) varLibrary.getVariableID(globalScopeInst, "HP");
@@ -112,8 +109,7 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 	@Test
 	public void testIllegalAddModifier()
 	{
-		varLibrary.assertLegalVariableID("HP", globalScope,
-			FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("HP", "Global", FormatUtilities.NUMBER_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number> hp =
 				(VariableID<Number>) varLibrary.getVariableID(globalScopeInst, "HP");
@@ -136,8 +132,7 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 	@Test
 	public void testAddModifier()
 	{
-		varLibrary.assertLegalVariableID("HP", globalScope,
-			FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("HP", "Global", FormatUtilities.NUMBER_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number> hp =
 				(VariableID<Number>) varLibrary.getVariableID(globalScopeInst, "HP");
@@ -150,8 +145,7 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 		assertEquals(6, store.get(hp));
 
 		//Create not required...
-		varLibrary.assertLegalVariableID("HitPoints", globalScope,
-			FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("HitPoints", "Global", FormatUtilities.NUMBER_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number> hitpoints = (VariableID<Number>) varLibrary
 			.getVariableID(globalScopeInst, "HitPoints");
@@ -177,12 +171,9 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 		ComplexNEPFormula<Number> formula =
 				new ComplexNEPFormula<>("arms+legs", FormatUtilities.NUMBER_MANAGER);
 		Modifier<Number> formulaMod = AbstractModifier.add(formula, 100);
-		varLibrary.assertLegalVariableID("Limbs", globalScope,
-			FormatUtilities.NUMBER_MANAGER);
-		varLibrary.assertLegalVariableID("arms", globalScope,
-			FormatUtilities.NUMBER_MANAGER);
-		varLibrary.assertLegalVariableID("legs", globalScope,
-			FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("Limbs", "Global", FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("arms", "Global", FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("legs", "Global", FormatUtilities.NUMBER_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number> limbs =
 				(VariableID<Number>) varLibrary.getVariableID(globalScopeInst, "Limbs");
@@ -227,23 +218,19 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 				new ComplexNEPFormula<>("fingers/5", FormatUtilities.NUMBER_MANAGER);
 		Modifier<Number> handsMod = AbstractModifier.add(handsformula, 100);
 
-		varLibrary.assertLegalVariableID("Limbs", globalScope,
-			FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("Limbs", "Global", FormatUtilities.NUMBER_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number> limbs =
 				(VariableID<Number>) varLibrary.getVariableID(globalScopeInst, "Limbs");
-		varLibrary.assertLegalVariableID("arms", globalScope,
-			FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("arms", "Global", FormatUtilities.NUMBER_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number> arms =
 				(VariableID<Number>) varLibrary.getVariableID(globalScopeInst, "Arms");
-		varLibrary.assertLegalVariableID("Fingers", globalScope,
-			FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("Fingers", "Global", FormatUtilities.NUMBER_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number> fingers =
 				(VariableID<Number>) varLibrary.getVariableID(globalScopeInst, "Fingers");
-		varLibrary.assertLegalVariableID("legs", globalScope,
-			FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("legs", "Global", FormatUtilities.NUMBER_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number> legs =
 				(VariableID<Number>) varLibrary.getVariableID(globalScopeInst, "Legs");
@@ -276,8 +263,7 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 	@Test
 	public void testIllegalRemoveModifier()
 	{
-		varLibrary.assertLegalVariableID("HP", globalScope,
-			FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("HP", "Global", FormatUtilities.NUMBER_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number> hp =
 				(VariableID<Number>) varLibrary.getVariableID(globalScopeInst, "HP");
@@ -315,23 +301,19 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 				new ComplexNEPFormula<>("limbs*5", FormatUtilities.NUMBER_MANAGER);
 		Modifier<Number> fingersMod = AbstractModifier.add(fingersformula, 100);
 
-		varLibrary.assertLegalVariableID("Limbs", globalScope,
-			FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("Limbs", "Global", FormatUtilities.NUMBER_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number> limbs =
 				(VariableID<Number>) varLibrary.getVariableID(globalScopeInst, "Limbs");
-		varLibrary.assertLegalVariableID("arms", globalScope,
-			FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("arms", "Global", FormatUtilities.NUMBER_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number> arms =
 				(VariableID<Number>) varLibrary.getVariableID(globalScopeInst, "Arms");
-		varLibrary.assertLegalVariableID("Fingers", globalScope,
-			FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("Fingers", "Global", FormatUtilities.NUMBER_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number> fingers =
 				(VariableID<Number>) varLibrary.getVariableID(globalScopeInst, "Fingers");
-		varLibrary.assertLegalVariableID("legs", globalScope,
-			FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("legs", "Global", FormatUtilities.NUMBER_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number> legs =
 				(VariableID<Number>) varLibrary.getVariableID(globalScopeInst, "Legs");
@@ -371,11 +353,6 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 		return solverFactory;
 	}
 
-	public VariableLibrary getVarLibrary()
-	{
-		return varLibrary;
-	}
-
 	@Test
 	public void testIndependence()
 	{
@@ -388,23 +365,19 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 				new ComplexNEPFormula<>("fingers/5", FormatUtilities.NUMBER_MANAGER);
 		Modifier<Number> handsMod = AbstractModifier.add(handsformula, 100);
 
-		varLibrary.assertLegalVariableID("Limbs", globalScope,
-			FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("Limbs", "Global", FormatUtilities.NUMBER_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number> limbs =
 				(VariableID<Number>) varLibrary.getVariableID(globalScopeInst, "Limbs");
-		varLibrary.assertLegalVariableID("arms", globalScope,
-			FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("arms", "Global", FormatUtilities.NUMBER_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number> arms =
 				(VariableID<Number>) varLibrary.getVariableID(globalScopeInst, "Arms");
-		varLibrary.assertLegalVariableID("Fingers", globalScope,
-			FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("Fingers", "Global", FormatUtilities.NUMBER_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number> fingers =
 				(VariableID<Number>) varLibrary.getVariableID(globalScopeInst, "Fingers");
-		varLibrary.assertLegalVariableID("legs", globalScope,
-			FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("legs", "Global", FormatUtilities.NUMBER_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number> legs =
 				(VariableID<Number>) varLibrary.getVariableID(globalScopeInst, "Legs");
@@ -461,8 +434,7 @@ public abstract class AbstractSolverManagerTest extends AbstractFormulaTestCase
 				new ComplexNEPFormula<>("\"4\"", FormatUtilities.NUMBER_MANAGER);
 		Modifier<Number> strMod = AbstractModifier.add(fiveString, 200);
 
-		varLibrary.assertLegalVariableID("Limbs", globalScope,
-			FormatUtilities.NUMBER_MANAGER);
+		assertLegalVariable("Limbs", "Global", FormatUtilities.NUMBER_MANAGER);
 		@SuppressWarnings("unchecked")
 		VariableID<Number> limbs =
 				(VariableID<Number>) varLibrary.getVariableID(globalScopeInst, "Limbs");

--- a/PCGen-Formula/code/src/test/pcgen/base/testsupport/TestUtilities.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/testsupport/TestUtilities.java
@@ -21,6 +21,7 @@ import java.io.StringReader;
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
 
 import junit.framework.TestCase;
 import pcgen.base.format.ArrayFormatManager;
@@ -34,6 +35,7 @@ import pcgen.base.formula.parse.FormulaParser;
 import pcgen.base.formula.parse.ParseException;
 import pcgen.base.formula.parse.SimpleNode;
 import pcgen.base.util.FormatManager;
+import pcgen.base.util.ValueStore;
 
 public final class TestUtilities
 {
@@ -140,4 +142,14 @@ public final class TestUtilities
 
 		return instance;
 	}
+
+	public static ValueStore getDefaultValueStore()
+	{
+		HashMap<String, Object> map = new HashMap<>();
+		map.put("NUMBER", 0);
+		map.put("STRING", "");
+		map.put("BOOLEAN", Boolean.FALSE);
+		return map::get;
+	}
+
 }


### PR DESCRIPTION
Test Cleanup

- Avoids using fields when items are not complex to set up (avoids needing tearDown and avoids assuming what each test really needs)
- Centralizes a few resources to Abstract* or Support classes (basically isolates many of the files from planned changes in underlying classes)

