### PR TITLE
Extract OperatorLibrary from FormulaManager

### DIFF
--- a/PCGen-Formula/code/src/java/pcgen/base/formula/base/DependencyManager.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/base/DependencyManager.java
@@ -47,6 +47,8 @@ public class DependencyManager
 	 */
 	public static final TypedKey<FormulaManager> FMANAGER = new TypedKey<>();
 
+	public static final TypedKey<OperatorLibrary> OPLIB = new TypedKey<>();
+
 	/**
 	 * A TypedKey used for storing the LegalScope contained in this DependencyManager.
 	 * 

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/base/DependencyManager.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/base/DependencyManager.java
@@ -47,6 +47,9 @@ public class DependencyManager
 	 */
 	public static final TypedKey<FormulaManager> FMANAGER = new TypedKey<>();
 
+	/**
+	 * The OperatorLibrary used to store valid operators.
+	 */
 	public static final TypedKey<OperatorLibrary> OPLIB = new TypedKey<>();
 
 	/**

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/base/EvaluationManager.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/base/EvaluationManager.java
@@ -44,6 +44,9 @@ public final class EvaluationManager
 	 */
 	public static final TypedKey<FormulaManager> FMANAGER = new TypedKey<>();
 
+	/**
+	 * The OperatorLibrary used to store valid operators.
+	 */
 	public static final TypedKey<OperatorLibrary> OPLIB = new TypedKey<>();
 
 	/**

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/base/EvaluationManager.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/base/EvaluationManager.java
@@ -44,6 +44,8 @@ public final class EvaluationManager
 	 */
 	public static final TypedKey<FormulaManager> FMANAGER = new TypedKey<>();
 
+	public static final TypedKey<OperatorLibrary> OPLIB = new TypedKey<>();
+
 	/**
 	 * A TypedKey used for storing the ScopeInstance contained in this EvaluationManager.
 	 */

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/base/FormulaManager.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/base/FormulaManager.java
@@ -55,15 +55,6 @@ public interface FormulaManager
 	public VariableLibrary getFactory();
 
 	/**
-	 * Returns the OperatorLibrary used to store valid operations in this
-	 * FormulaManager.
-	 * 
-	 * @return The OperatorLibrary used to store valid operations in this
-	 *         FormulaManager
-	 */
-	public OperatorLibrary getOperatorLibrary();
-
-	/**
 	 * Returns the default value for a given FormatManager.
 	 * 
 	 * @param formatManager

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/base/FormulaSemantics.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/base/FormulaSemantics.java
@@ -52,6 +52,8 @@ public class FormulaSemantics
 	 */
 	public static final TypedKey<FormulaManager> FMANAGER = new TypedKey<>();
 
+	public static final TypedKey<OperatorLibrary> OPLIB = new TypedKey<>();
+
 	/**
 	 * A TypedKey used for storing the LegalScope contained in this FormulaSemantics.
 	 */

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/base/FormulaSemantics.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/base/FormulaSemantics.java
@@ -52,6 +52,9 @@ public class FormulaSemantics
 	 */
 	public static final TypedKey<FormulaManager> FMANAGER = new TypedKey<>();
 
+	/**
+	 * The OperatorLibrary used to store valid operators.
+	 */
 	public static final TypedKey<OperatorLibrary> OPLIB = new TypedKey<>();
 
 	/**

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/base/ManagerFactory.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/base/ManagerFactory.java
@@ -17,6 +17,7 @@
  */
 package pcgen.base.formula.base;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -24,8 +25,15 @@ import java.util.Optional;
  * the visitors to a Formula. This is an interface to allow extension of these behaviors
  * by more advanced formula processing systems.
  */
-public interface ManagerFactory
+public class ManagerFactory
 {
+	private final OperatorLibrary opLib;
+
+	public ManagerFactory(OperatorLibrary opLib)
+	{
+		this.opLib = Objects.requireNonNull(opLib);
+	}
+
 	/**
 	 * Generates an initialized DependencyManager with the given arguments.
 	 * 
@@ -35,10 +43,11 @@ public interface ManagerFactory
 	 *            The ScopeInstance to be contained in the DependencyManager
 	 * @return An initialized DependencyManager with the given arguments
 	 */
-	public default DependencyManager generateDependencyManager(
+	public DependencyManager generateDependencyManager(
 		FormulaManager formulaManager, ScopeInstance scopeInst)
 	{
 		DependencyManager fdm = new DependencyManager(formulaManager);
+		fdm = fdm.getWith(DependencyManager.OPLIB, opLib);
 		return fdm.getWith(DependencyManager.INSTANCE, scopeInst);
 	}
 
@@ -51,7 +60,7 @@ public interface ManagerFactory
 	 *            be derived
 	 * @return The DependencyManager with contents to handle variables
 	 */
-	public default DependencyManager withVariables(DependencyManager fdm)
+	public DependencyManager withVariables(DependencyManager fdm)
 	{
 		return fdm
 			.getWith(DependencyManager.VARSTRATEGY, Optional.of(new StaticStrategy()))
@@ -70,11 +79,12 @@ public interface ManagerFactory
 	 * @return An initialized FormulaSemantics object with the appropriate keys set to the
 	 *         given parameters
 	 */
-	public default FormulaSemantics generateFormulaSemantics(FormulaManager manager,
-		LegalScope legalScope)
+	public FormulaSemantics generateFormulaSemantics(
+		FormulaManager manager, LegalScope legalScope)
 	{
 		FormulaSemantics semantics = new FormulaSemantics();
 		semantics = semantics.getWith(FormulaSemantics.FMANAGER, manager);
+		semantics = semantics.getWith(FormulaSemantics.OPLIB, opLib);
 		return semantics.getWith(FormulaSemantics.SCOPE, legalScope);
 	}
 
@@ -86,10 +96,11 @@ public interface ManagerFactory
 	 *            EvaluationManager
 	 * @return A new EvaluationManager initialized with the given parameters
 	 */
-	public default EvaluationManager generateEvaluationManager(
+	public EvaluationManager generateEvaluationManager(
 		FormulaManager formulaManager)
 	{
 		EvaluationManager manager = new EvaluationManager();
+		manager = manager.getWith(EvaluationManager.OPLIB, opLib);
 		return manager.getWith(EvaluationManager.FMANAGER, formulaManager);
 	}
 

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/inst/SimpleFormulaManager.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/inst/SimpleFormulaManager.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import pcgen.base.formula.base.FormulaManager;
-import pcgen.base.formula.base.OperatorLibrary;
 import pcgen.base.formula.base.ScopeInstanceFactory;
 import pcgen.base.formula.base.VariableLibrary;
 import pcgen.base.formula.base.VariableStore;
@@ -48,11 +47,6 @@ public class SimpleFormulaManager implements FormulaManager
 	private final ValueStore defaultStore;
 
 	/**
-	 * The OperatorLibrary used to store valid operators in this FormulaManager.
-	 */
-	private final OperatorLibrary opLibrary;
-
-	/**
 	 * The VariableLibrary used to get VariableIDs.
 	 */
 	private final VariableLibrary varLibrary;
@@ -66,8 +60,6 @@ public class SimpleFormulaManager implements FormulaManager
 	 * Constructs a new FormulaManager from the provided FunctionLibrary, OperatorLibrary,
 	 * VariableLibrary, and VariableStore.
 	 * 
-	 * @param opLibrary
-	 *            The OperatorLibrary used to store valid operators in this FormulaManager
 	 * @param varLibrary
 	 *            The VariableLibrary used to get VariableIDs
 	 * @param siFactory
@@ -78,11 +70,10 @@ public class SimpleFormulaManager implements FormulaManager
 	 * @param defaultStore
 	 *            The ValueStore used to know default values for each format (class)
 	 */
-	public SimpleFormulaManager(OperatorLibrary opLibrary, VariableLibrary varLibrary,
+	public SimpleFormulaManager(VariableLibrary varLibrary,
 		ScopeInstanceFactory siFactory, VariableStore resultStore,
 		ValueStore defaultStore)
 	{
-		this.opLibrary = Objects.requireNonNull(opLibrary);
 		this.varLibrary = Objects.requireNonNull(varLibrary);
 		this.siFactory = Objects.requireNonNull(siFactory);
 		map.put(RESULTS, Objects.requireNonNull(resultStore));
@@ -91,7 +82,6 @@ public class SimpleFormulaManager implements FormulaManager
 	
 	private SimpleFormulaManager(SimpleFormulaManager original, Map<TypedKey<?>, Object> map)
 	{
-		this.opLibrary = original.opLibrary;
 		this.varLibrary = original.varLibrary;
 		this.siFactory = original.siFactory;
 		this.defaultStore = original.defaultStore;
@@ -107,17 +97,6 @@ public class SimpleFormulaManager implements FormulaManager
 	public VariableLibrary getFactory()
 	{
 		return varLibrary;
-	}
-
-	/**
-	 * Returns the OperatorLibrary used to store valid operations in this FormulaManager.
-	 * 
-	 * @return The OperatorLibrary used to store valid operations in this FormulaManager
-	 */
-	@Override
-	public OperatorLibrary getOperatorLibrary()
-	{
-		return opLibrary;
 	}
 
 	@Override

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/visitor/DependencyVisitor.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/visitor/DependencyVisitor.java
@@ -340,8 +340,7 @@ public class DependencyVisitor implements FormulaParserVisitor
 		Node child2 = node.jjtGetChild(1);
 		@SuppressWarnings("unchecked")
 		Optional<FormatManager<?>> format2 = (Optional<FormatManager<?>>) child2.jjtAccept(this, data);
-		OperatorLibrary opLib =
-				manager.get(DependencyManager.FMANAGER).getOperatorLibrary();
+		OperatorLibrary opLib = manager.get(DependencyManager.OPLIB);
 		Operator op = node.getOperator();
 		return opLib.processAbstract(op, format1.get().getManagedClass(),
 			format2.get().getManagedClass(), manager.get(DependencyManager.ASSERTED));
@@ -353,8 +352,7 @@ public class DependencyVisitor implements FormulaParserVisitor
 		@SuppressWarnings("unchecked")
 		Optional<FormatManager<?>> format = (Optional<FormatManager<?>>) child.jjtAccept(this, data);
 		DependencyManager manager = (DependencyManager) data;
-		OperatorLibrary opLib =
-				manager.get(DependencyManager.FMANAGER).getOperatorLibrary();
+		OperatorLibrary opLib = manager.get(DependencyManager.OPLIB);
 		Operator op = node.getOperator();
 		return opLib.processAbstract(op, format.get().getManagedClass());
 	}

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/visitor/EvaluateVisitor.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/visitor/EvaluateVisitor.java
@@ -312,8 +312,7 @@ public class EvaluateVisitor implements FormulaParserVisitor
 		Object child1result = node.jjtGetChild(0).jjtAccept(this, data);
 		Object child2result = node.jjtGetChild(1).jjtAccept(this, data);
 		EvaluationManager manager = (EvaluationManager) data;
-		OperatorLibrary opLib =
-				manager.get(EvaluationManager.FMANAGER).getOperatorLibrary();
+		OperatorLibrary opLib = manager.get(EvaluationManager.OPLIB);
 		Optional<FormatManager<?>> asserted = manager.get(EvaluationManager.ASSERTED);
 		return opLib.evaluate(node.getOperator(), child1result, child2result, asserted);
 	}
@@ -333,8 +332,7 @@ public class EvaluateVisitor implements FormulaParserVisitor
 	{
 		Object result = node.jjtGetChild(0).jjtAccept(this, data);
 		EvaluationManager manager = (EvaluationManager) data;
-		OperatorLibrary opLib =
-				manager.get(EvaluationManager.FMANAGER).getOperatorLibrary();
+		OperatorLibrary opLib = manager.get(EvaluationManager.OPLIB);
 		return opLib.evaluate(node.getOperator(), result);
 	}
 

--- a/PCGen-Formula/code/src/java/pcgen/base/formula/visitor/SemanticsVisitor.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/formula/visitor/SemanticsVisitor.java
@@ -457,8 +457,7 @@ public class SemanticsVisitor implements FormulaParserVisitor
 		FormatManager<?> format2 = (FormatManager<?>) child2.jjtAccept(this, data);
 
 		FormulaSemantics semantics = (FormulaSemantics) data;
-		OperatorLibrary opLib =
-				semantics.get(FormulaSemantics.FMANAGER).getOperatorLibrary();
+		OperatorLibrary opLib = semantics.get(FormulaSemantics.OPLIB);
 		Optional<FormatManager<?>> asserted = semantics.get(FormulaSemantics.ASSERTED);
 		Optional<FormatManager<?>> returnedFormat = opLib.processAbstract(op,
 			format1.getManagedClass(), format2.getManagedClass(), asserted);
@@ -481,8 +480,7 @@ public class SemanticsVisitor implements FormulaParserVisitor
 		FormatManager<?> format = (FormatManager<?>) singleChildValid(node, data);
 
 		FormulaSemantics semantics = (FormulaSemantics) data;
-		OperatorLibrary opLib =
-				semantics.get(FormulaSemantics.FMANAGER).getOperatorLibrary();
+		OperatorLibrary opLib = semantics.get(FormulaSemantics.OPLIB);
 		Optional<FormatManager<?>> returnedFormat = opLib.processAbstract(op, format.getManagedClass());
 		return returnedFormat.orElseThrow(() -> new SemanticsFailureException(
 			"Parse Error: Operator " + op.getSymbol()

--- a/PCGen-Formula/code/src/java/pcgen/base/solver/FormulaSetupFactory.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/solver/FormulaSetupFactory.java
@@ -21,7 +21,6 @@ import java.util.function.Supplier;
 
 import pcgen.base.formula.base.FormulaManager;
 import pcgen.base.formula.base.FunctionLibrary;
-import pcgen.base.formula.base.OperatorLibrary;
 import pcgen.base.formula.base.ScopeInstanceFactory;
 import pcgen.base.formula.base.VariableLibrary;
 import pcgen.base.formula.base.VariableStore;
@@ -30,7 +29,6 @@ import pcgen.base.formula.inst.LegalScopeManager;
 import pcgen.base.formula.inst.ScopeManagerInst;
 import pcgen.base.formula.inst.SimpleFormulaManager;
 import pcgen.base.formula.inst.SimpleFunctionLibrary;
-import pcgen.base.formula.inst.SimpleOperatorLibrary;
 import pcgen.base.formula.inst.SimpleScopeInstanceFactory;
 import pcgen.base.formula.inst.SimpleVariableStore;
 import pcgen.base.formula.inst.VariableManager;
@@ -64,12 +62,6 @@ public class FormulaSetupFactory
 			() -> FormulaUtilities.loadBuiltInFunctions(new SimpleFunctionLibrary());
 
 	/**
-	 * The SimpleOperatorLibrary for this FormulaSetupFactory.
-	 */
-	private Supplier<OperatorLibrary> operatorLibrarySupplier =
-			() -> FormulaUtilities.loadBuiltInOperators(new SimpleOperatorLibrary());
-
-	/**
 	 * The VariableLibrary for this FormulaSetupFactory.
 	 */
 	private BiFunction<LegalScopeManager, ValueStore, VariableLibrary> variableLibraryFunction =
@@ -99,13 +91,12 @@ public class FormulaSetupFactory
 		SupplierValueStore valueStore = valueStoreSupplier.get();
 		LegalScopeManager legalScopeManager = legalScopeManagerSupplier.get();
 		FunctionLibrary functionLibrary = functionLibrarySupplier.get();
-		OperatorLibrary operatorLibrary = operatorLibrarySupplier.get();
 		VariableStore variableStore = variableStoreSupplier.get();
 		VariableLibrary variableLibrary =
 				variableLibraryFunction.apply(legalScopeManager, valueStore);
 		ScopeInstanceFactory scopeInstanceFactory =
 				scopeInstanceFactoryFunction.apply(legalScopeManager);
-		SimpleFormulaManager fManager = new SimpleFormulaManager(operatorLibrary,
+		SimpleFormulaManager fManager = new SimpleFormulaManager(
 			variableLibrary, scopeInstanceFactory, variableStore, valueStore);
 		return fManager.getWith(FormulaManager.FUNCTION, functionLibrary);
 	}
@@ -149,20 +140,6 @@ public class FormulaSetupFactory
 		Supplier<FunctionLibrary> functionLibrarySupplier)
 	{
 		this.functionLibrarySupplier = functionLibrarySupplier;
-	}
-
-	/**
-	 * Sets the Supplier that will generate a OperatorLibrary for this
-	 * FormulaSetupFactory.
-	 * 
-	 * @param operatorLibrarySupplier
-	 *            The Supplier that will generate a OperatorLibrary for this
-	 *            FormulaSetupFactory
-	 */
-	public void setOperatorLibrarySupplier(
-		Supplier<OperatorLibrary> operatorLibrarySupplier)
-	{
-		this.operatorLibrarySupplier = operatorLibrarySupplier;
 	}
 
 	/**

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/ComplexNEPFormulaTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/ComplexNEPFormulaTest.java
@@ -19,7 +19,6 @@ import pcgen.base.formula.base.VariableID;
 import pcgen.base.formula.base.VariableList;
 import pcgen.base.formula.exception.SemanticsException;
 import pcgen.base.testsupport.AbstractFormulaTestCase;
-import pcgen.base.testsupport.TestUtilities;
 
 public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 {
@@ -228,9 +227,9 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 
 	private DependencyManager setupDM()
 	{
-		DependencyManager dm = TestUtilities.EMPTY_MGR_FACTORY
+		DependencyManager dm = getManagerFactory()
 			.generateDependencyManager(getFormulaManager(), getGlobalScopeInst());
-		dm = TestUtilities.EMPTY_MGR_FACTORY.withVariables(dm);
+		dm = getManagerFactory().withVariables(dm);
 		return dm.getWith(ArgumentDependencyManager.KEY,
 			Optional.of(new ArgumentDependencyManager()));
 	}
@@ -341,7 +340,7 @@ public class ComplexNEPFormulaTest extends AbstractFormulaTestCase
 
 	private FormulaSemantics getSemantics()
 	{
-		return TestUtilities.EMPTY_MGR_FACTORY.generateFormulaSemantics(getFormulaManager(),
+		return getManagerFactory().generateFormulaSemantics(getFormulaManager(),
 			getInstanceFactory().getScope("Global"));
 	}
 }

--- a/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleFormulaManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/formula/inst/SimpleFormulaManagerTest.java
@@ -33,7 +33,6 @@ public class SimpleFormulaManagerTest
 {
 
 	private VariableLibrary variableLibrary;
-	private SimpleOperatorLibrary opLibrary;
 	private SimpleVariableStore resultsStore;
 	private ScopeInstanceFactory siFactory;
 	private SupplierValueStore valueStore;
@@ -48,7 +47,6 @@ public class SimpleFormulaManagerTest
 		resultsStore = new SimpleVariableStore();
 		LegalScopeManager legalScopeManager = new ScopeManagerInst();
 		variableLibrary = new VariableManager(legalScopeManager, valueStore);
-		opLibrary = new SimpleOperatorLibrary();
 		siFactory = new SimpleScopeInstanceFactory(legalScopeManager);
 	}
 	
@@ -56,7 +54,6 @@ public class SimpleFormulaManagerTest
 	void tearDown()
 	{
 		variableLibrary = null;
-		opLibrary = null;
 		resultsStore = null;
 		siFactory = null;
 		valueStore = null;
@@ -65,18 +62,17 @@ public class SimpleFormulaManagerTest
 	@Test
 	public void testDoubleConstructor()
 	{
-		assertThrows(NullPointerException.class, () -> new SimpleFormulaManager(null, null, null, null, null));
-		assertThrows(NullPointerException.class, () -> new SimpleFormulaManager(null, variableLibrary, siFactory, resultsStore, valueStore));
-		assertThrows(NullPointerException.class, () -> new SimpleFormulaManager(opLibrary, null, siFactory, resultsStore, valueStore));
-		assertThrows(NullPointerException.class, () -> new SimpleFormulaManager(opLibrary, variableLibrary, null, resultsStore, valueStore));
-		assertThrows(NullPointerException.class, () -> new SimpleFormulaManager(opLibrary, variableLibrary, siFactory, null, valueStore));
-		assertThrows(NullPointerException.class, () -> new SimpleFormulaManager(opLibrary, variableLibrary, siFactory, resultsStore, null));
+		assertThrows(NullPointerException.class, () -> new SimpleFormulaManager(null, null, null, null));
+		assertThrows(NullPointerException.class, () -> new SimpleFormulaManager(null, siFactory, resultsStore, valueStore));
+		assertThrows(NullPointerException.class, () -> new SimpleFormulaManager(variableLibrary, null, resultsStore, valueStore));
+		assertThrows(NullPointerException.class, () -> new SimpleFormulaManager(variableLibrary, siFactory, null, valueStore));
+		assertThrows(NullPointerException.class, () -> new SimpleFormulaManager(variableLibrary, siFactory, resultsStore, null));
 	}
 
 	@Test
 	public void testGetDefault()
 	{
-		FormulaManager formulaManager = new SimpleFormulaManager(opLibrary, variableLibrary, siFactory,
+		FormulaManager formulaManager = new SimpleFormulaManager(variableLibrary, siFactory,
 			resultsStore, valueStore);
 		assertEquals(0,formulaManager.getDefault(FormatUtilities.NUMBER_MANAGER));
 		assertEquals("", formulaManager.getDefault(FormatUtilities.STRING_MANAGER));

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/AggressiveSolverManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/AggressiveSolverManagerTest.java
@@ -35,7 +35,6 @@ import pcgen.base.formula.inst.SimpleLegalScope;
 import pcgen.base.solver.testsupport.AbstractModifier;
 import pcgen.base.solver.testsupport.AbstractSolverManagerTest;
 import pcgen.base.solver.testsupport.MockStat;
-import pcgen.base.testsupport.TestUtilities;
 
 public class AggressiveSolverManagerTest extends AbstractSolverManagerTest
 {
@@ -46,7 +45,7 @@ public class AggressiveSolverManagerTest extends AbstractSolverManagerTest
 	protected void setUp()
 	{
 		super.setUp();
-		manager = new AggressiveSolverManager(getFormulaManager(), TestUtilities.EMPTY_MGR_FACTORY,
+		manager = new AggressiveSolverManager(getFormulaManager(), getManagerFactory(),
 			getSolverFactory(), getVariableStore());
 	}
 	
@@ -61,11 +60,11 @@ public class AggressiveSolverManagerTest extends AbstractSolverManagerTest
 	@Test
 	public void testIllegalConstruction()
 	{
-		assertThrows(NullPointerException.class, () -> new AggressiveSolverManager(null, TestUtilities.EMPTY_MGR_FACTORY, getSolverFactory(), getVariableStore()));
+		assertThrows(NullPointerException.class, () -> new AggressiveSolverManager(null, getManagerFactory(), getSolverFactory(), getVariableStore()));
 		FormulaManager formulaManager = getFormulaManager();
 		assertThrows(NullPointerException.class, () -> new AggressiveSolverManager(formulaManager, null, getSolverFactory(), getVariableStore()));
-		assertThrows(NullPointerException.class, () -> new AggressiveSolverManager(formulaManager, TestUtilities.EMPTY_MGR_FACTORY, getSolverFactory(), null));
-		assertThrows(NullPointerException.class, () -> new AggressiveSolverManager(formulaManager, TestUtilities.EMPTY_MGR_FACTORY, getSolverFactory(), null));
+		assertThrows(NullPointerException.class, () -> new AggressiveSolverManager(formulaManager, getManagerFactory(), getSolverFactory(), null));
+		assertThrows(NullPointerException.class, () -> new AggressiveSolverManager(formulaManager, getManagerFactory(), getSolverFactory(), null));
 	}
 
 	@Test

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/DynamicSolverManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/DynamicSolverManagerTest.java
@@ -49,7 +49,6 @@ import pcgen.base.formula.visitor.SemanticsVisitor;
 import pcgen.base.formula.visitor.StaticVisitor;
 import pcgen.base.solver.testsupport.AbstractModifier;
 import pcgen.base.solver.testsupport.AbstractSolverManagerTest;
-import pcgen.base.testsupport.TestUtilities;
 import pcgen.base.util.BasicIndirect;
 import pcgen.base.util.CaseInsensitiveMap;
 import pcgen.base.util.FormatManager;
@@ -65,7 +64,7 @@ public class DynamicSolverManagerTest extends AbstractSolverManagerTest
 	protected void setUp()
 	{
 		super.setUp();
-		manager = new DynamicSolverManager(getFormulaManager(), TestUtilities.EMPTY_MGR_FACTORY,
+		manager = new DynamicSolverManager(getFormulaManager(), getManagerFactory(),
 			getSolverFactory(), getVariableStore());
 		limbManager = new LimbManager();
 		getValueStore().addSolverFormat(limbManager,
@@ -84,14 +83,14 @@ public class DynamicSolverManagerTest extends AbstractSolverManagerTest
 	@Test
 	public void testIllegalConstruction()
 	{
-		assertThrows(NullPointerException.class, () -> new DynamicSolverManager(null, TestUtilities.EMPTY_MGR_FACTORY, getSolverFactory(),
+		assertThrows(NullPointerException.class, () -> new DynamicSolverManager(null, getManagerFactory(), getSolverFactory(),
 				getVariableStore()));
 		FormulaManager formulaManager = getFormulaManager();
 		assertThrows(NullPointerException.class, () -> new DynamicSolverManager(formulaManager, null, getSolverFactory(),
 				getVariableStore()));
-		assertThrows(NullPointerException.class, () -> new DynamicSolverManager(formulaManager, TestUtilities.EMPTY_MGR_FACTORY, null,
+		assertThrows(NullPointerException.class, () -> new DynamicSolverManager(formulaManager, getManagerFactory(), null,
 				getVariableStore()));
-		assertThrows(NullPointerException.class, () -> new DynamicSolverManager(formulaManager, TestUtilities.EMPTY_MGR_FACTORY, getSolverFactory(),
+		assertThrows(NullPointerException.class, () -> new DynamicSolverManager(formulaManager, getManagerFactory(), getSolverFactory(),
 				null));
 	}
 

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/SolverTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/SolverTest.java
@@ -33,11 +33,15 @@ import org.junit.jupiter.api.Test;
 import pcgen.base.formatmanager.FormatUtilities;
 import pcgen.base.formula.base.EvaluationManager;
 import pcgen.base.formula.base.FormulaManager;
+import pcgen.base.formula.base.ManagerFactory;
+import pcgen.base.formula.base.OperatorLibrary;
 import pcgen.base.formula.base.ScopeInstance;
 import pcgen.base.formula.base.ScopeInstanceFactory;
+import pcgen.base.formula.inst.FormulaUtilities;
 import pcgen.base.formula.inst.GlobalVarScoped;
 import pcgen.base.formula.inst.ScopeManagerInst;
 import pcgen.base.formula.inst.SimpleLegalScope;
+import pcgen.base.formula.inst.SimpleOperatorLibrary;
 import pcgen.base.solver.testsupport.AbstractModifier;
 import pcgen.base.solver.testsupport.MockStat;
 import pcgen.base.testsupport.TestUtilities;
@@ -64,7 +68,9 @@ public class SolverTest
 		inst = scopeInstanceFactory.get("Global", Optional.of(new GlobalVarScoped("Global")));
 		str = scopeInstanceFactory.get("Global.STAT", Optional.of(new MockStat("STR")));
 		con = scopeInstanceFactory.get("Global.STAT", Optional.of(new MockStat("CON")));
-		evalManager = TestUtilities.EMPTY_MGR_FACTORY.generateEvaluationManager(formulaManager);
+		OperatorLibrary opLibrary = FormulaUtilities.loadBuiltInOperators(new SimpleOperatorLibrary());
+		ManagerFactory managerFactory = new ManagerFactory(opLibrary);
+		evalManager = managerFactory.generateEvaluationManager(formulaManager);
 	}
 
 	@AfterEach

--- a/PCGen-Formula/code/src/test/pcgen/base/testsupport/TestUtilities.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/testsupport/TestUtilities.java
@@ -29,7 +29,6 @@ import pcgen.base.format.NumberManager;
 import pcgen.base.formatmanager.ArrayFormatFactory;
 import pcgen.base.formatmanager.CompoundFormatFactory;
 import pcgen.base.formatmanager.FormatUtilities;
-import pcgen.base.formula.base.ManagerFactory;
 import pcgen.base.formula.parse.FormulaParser;
 import pcgen.base.formula.parse.ParseException;
 import pcgen.base.formula.parse.SimpleNode;
@@ -40,10 +39,6 @@ public final class TestUtilities
 	public static final double SMALL_ERROR = Math.pow(10, -10);
 
 	public static final Number[] EMPTY_ARRAY = {};
-
-	public static final ManagerFactory EMPTY_MGR_FACTORY = new ManagerFactory()
-	{
-	};
 
 	public static final ArrayFormatFactory ARRAY_FACTORY =
 			new ArrayFormatFactory('\n', ',');


### PR DESCRIPTION
First part of reducing the function of FormulaManager - it's just a data class (and a redundant one most of the time) that causes many a.get(x).getB().c() calls, whereas a.get(y).c() is better (recognizing a is a vastly used and expandable database, so a.c() is really not realistic).