### PR TITLE
 Extract the SolverStrategy concept from the SolverManager objects

### DIFF
--- a/PCGen-Formula/code/src/java/pcgen/base/solver/AggressiveStrategy.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/solver/AggressiveStrategy.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2020 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.solver;
+
+import java.util.Objects;
+import java.util.Stack;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import pcgen.base.formula.base.VariableID;
+
+/**
+ * An AggressiveStrategy is a SolverStrategy that will immediately calculate the result of
+ * a VariableID when any incoming dependency potentially changes the value.
+ */
+public class AggressiveStrategy implements SolverStrategy
+{
+	/**
+	 * The Stack, used during processing, to identify what items are being processed and
+	 * to detect loops.
+	 */
+	private final Stack<VariableID<?>> varStack = new Stack<>();
+
+	/**
+	 * The Function used to solve a given VariableID.  Must return true if the value changed.
+	 */
+	private final Function<VariableID<?>, Boolean> solveProcessor;
+
+	/**
+	 * The BiConsumer used to process an item on all dependents of a VariableID.
+	 */
+	private final BiConsumer<VariableID<?>, Consumer<VariableID<?>>> depConsumer;
+
+	/**
+	 * Constructs a new AggressiveStrategy with the given arguments.
+	 * 
+	 * @param depConsumer
+	 *            The BiConsumer used to process an item on all dependents of a
+	 *            VariableID
+	 * @param solveProcessor
+	 *            The Function used to solve a given VariableID. Must return true if the
+	 *            value changed
+	 */
+	public AggressiveStrategy(BiConsumer<VariableID<?>,
+		Consumer<VariableID<?>>> depConsumer,
+		Function<VariableID<?>, Boolean> solveProcessor)
+	{
+		this.depConsumer = Objects.requireNonNull(depConsumer);
+		this.solveProcessor = Objects.requireNonNull(solveProcessor);
+	}
+
+	@Override
+	public void processModsUpdated(VariableID<?> varID)
+	{
+		solveFromNode(varID);
+	}
+
+	/**
+	 * Triggers Solvers to be called, recursively through the dependencies, from the given
+	 * VariableID.
+	 * 
+	 * @param varID
+	 *            The VariableID as a starting point for triggering Solvers to be
+	 *            processed
+	 */
+	private boolean solveFromNode(VariableID<?> varID)
+	{
+		boolean changed = false;
+		boolean loopIfChanged = varStack.contains(varID);
+		try
+		{
+			varStack.push(varID);
+			changed = solveProcessor.apply(varID);
+			if (changed)
+			{
+				if (loopIfChanged)
+				{
+					throw new IllegalStateException(
+						"Infinite Loop in Variable Processing: " + varStack);
+				}
+				/*
+				 * Only necessary if the answer changes. The problem is that this is not
+				 * doing them in order of a topological sort - it is completely random...
+				 * so things may be processed twice :/
+				 */
+				solveChildren(varID);
+			}
+		}
+		finally
+		{
+			varStack.pop();
+		}
+		return changed;
+	}
+
+	/**
+	 * Solves children of (any VariableID dependent upon) the given VariableID.
+	 * 
+	 * @param varID
+	 *            The VariableID for which the children should be solved
+	 */
+	private void solveChildren(VariableID<?> varID)
+	{
+		depConsumer.accept(varID, this::solveFromNode);
+	}
+
+	@Override
+	public AggressiveStrategy generateReplacement(
+		BiConsumer<VariableID<?>, Consumer<VariableID<?>>> newDepConsumer,
+		Function<VariableID<?>, Boolean> newSolver)
+	{
+		return new AggressiveStrategy(newDepConsumer, newSolver);
+	}
+
+}

--- a/PCGen-Formula/code/src/java/pcgen/base/solver/SolverStrategy.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/solver/SolverStrategy.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.solver;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import pcgen.base.formula.base.VariableID;
+
+/**
+ * A SolverStrategy is the analyzer of the dependencies in a SolverSystem, and decides the
+ * method used to calculate the results of the VariableIDs defined in that system.
+ */
+public interface SolverStrategy
+{
+
+	/**
+	 * Notifies the SolverStrategy that the process to calculate the result of a given
+	 * VariableID has been updated.
+	 * 
+	 * @param varID
+	 *            The VariableID where the inputs have been updated
+	 */
+	public void processModsUpdated(VariableID<?> varID);
+
+	/**
+	 * Generates a Replacement SolverStrategy with the given arguments.
+	 * 
+	 * @param depManager
+	 *            The new SolverDependencyManager for the replacement SolverStrategy
+	 * @param solver
+	 *            The new Function used to solve a given VariableID. Must return true if
+	 *            the value changed.
+	 * @return A Replacement SolverStrategy with the given arguments
+	 */
+	public SolverStrategy generateReplacement(
+		BiConsumer<VariableID<?>, Consumer<VariableID<?>>> depManager,
+		Function<VariableID<?>, Boolean> solver);
+
+}

--- a/PCGen-Formula/code/src/java/pcgen/base/solver/SolverSystem.java
+++ b/PCGen-Formula/code/src/java/pcgen/base/solver/SolverSystem.java
@@ -61,32 +61,6 @@ public interface SolverSystem
 		ScopeInstance source);
 
 	/**
-	 * Adds a Modifier (with the given source object) to the variable identified by the
-	 * given VariableID and solves for the given VariableID. Returns true if the added
-	 * modifier caused the value of the VariableID to change.
-	 * 
-	 * Note: If the SolverSystem is not aggressive, then the SolverSystem may 
-	 * interpret more than one Modifier as new to the underlying variable.  The return
-	 * value of this method is open to interpretation by the SolverSystem to 
-	 * determine if it limits it to only the provided Modifier or any Modifier since
-	 * the last time the variable was analyzed.
-	 * 
-	 * @param <T>
-	 *            The format (class) of object contained by the given VariableID
-	 * @param varID
-	 *            The VariableID for which a Modifier should be added to the responsible
-	 *            variable
-	 * @param modifier
-	 *            The Modifier to be added to the variable for the given VariableID
-	 * @param source
-	 *            The source of the Modifier to be added to the variable
-	 * @return true if the given VariableID was modified by adding the given variable, false
-	 *         otherwise
-	 */
-	public <T> boolean addModifierAndSolve(VariableID<T> varID, Modifier<T> modifier,
-		ScopeInstance source);
-
-	/**
 	 * Removes a Modifier (with the given source object) from the Solver identified by the
 	 * given VariableID.
 	 * 
@@ -138,16 +112,6 @@ public interface SolverSystem
 	 * @return The Default Value for the given Variable Format.
 	 */
 	public <T> T getDefaultValue(FormatManager<T> formatManager);
-
-	/**
-	 * Triggers variables to be resolved, recursively through the dependencies, from the
-	 * children of the given VariableID.
-	 * 
-	 * @param varID
-	 *            The VariableID for which the children will be used as a starting point
-	 *            for triggering variables to be processed
-	 */
-	public void solveChildren(VariableID<?> varID);
 
 	/**
 	 * Creates a replacement SolverSystem for this SolverSystem. The replacement will

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/AggressiveSolverManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/AggressiveSolverManagerTest.java
@@ -67,16 +67,6 @@ public class AggressiveSolverManagerTest extends AbstractSolverManagerTest
 		assertThrows(NullPointerException.class, () -> new AggressiveSolverManager(formulaManager, getManagerFactory(), getSolverFactory(), null));
 	}
 
-	@Test
-	public void testTrivial()
-	{
-		assertLegalVariable("Limbs", "Global", FormatUtilities.NUMBER_MANAGER);
-		@SuppressWarnings("unchecked")
-		VariableID<Number> limbs = (VariableID<Number>) getVariableLibrary()
-			.getVariableID(getGlobalScopeInst(), "Limbs");
-		manager.solveChildren(limbs);
-	}
-
 	@Override
 	protected SolverSystem getManager()
 	{

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/AggressiveStrategyTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/AggressiveStrategyTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 (C) Tom Parker <thpr@users.sourceforge.net>
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this library; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+ * Suite 330, Boston, MA 02111-1307 USA
+ */
+package pcgen.base.solver;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Test;
+
+import pcgen.base.formatmanager.FormatUtilities;
+import pcgen.base.formula.base.VariableID;
+import pcgen.base.testsupport.AbstractFormulaTestCase;
+import pcgen.base.testsupport.TestUtilities.Container;
+
+public class AggressiveStrategyTest extends AbstractFormulaTestCase
+{
+	@Test
+	public void testIllegalConstruction()
+	{
+		assertThrows(NullPointerException.class, () -> new AggressiveStrategy(null, var -> true));
+		assertThrows(NullPointerException.class, () -> new AggressiveStrategy((varID, consumer) -> {}, null));
+	}
+
+	@Test
+	public void testAddModifierExternal()
+	{
+		VariableID<Number> parent = new VariableID<>(getGlobalScopeInst(),
+				FormatUtilities.NUMBER_MANAGER, "STR");
+		VariableID<Number> child = new VariableID<>(getGlobalScopeInst(),
+				FormatUtilities.NUMBER_MANAGER, "LIFT");
+
+		Container<VariableID<?>> target = new Container<>();
+		ChildProcessor proc = new ChildProcessor(child);
+
+		SolverStrategy strategy = new AggressiveStrategy(proc::processForChildren, target::set);
+		
+		assertTrue(target.objects.isEmpty());
+		strategy.processModsUpdated(parent);
+		assertTrue(target.objects.get(0).equals(parent));
+		assertTrue(target.objects.get(1).equals(child));
+		assertTrue(proc.parent.equals(parent));
+	}
+	
+	private class ChildProcessor
+	{
+		private final VariableID<?> toDrive;
+		
+		public ChildProcessor(VariableID<?> toDrive)
+		{
+			this.toDrive = toDrive;
+		}
+
+		public VariableID<?> parent;
+		
+		public void processForChildren(VariableID<?> varID,
+			Consumer<VariableID<?>> consumer)
+		{
+			if (varID.equals(toDrive))
+			{
+				return;
+			}
+			parent = varID;
+			consumer.accept(toDrive);
+		}
+		
+	}
+
+}

--- a/PCGen-Formula/code/src/test/pcgen/base/solver/DynamicSolverManagerTest.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/solver/DynamicSolverManagerTest.java
@@ -162,16 +162,6 @@ public class DynamicSolverManagerTest extends AbstractSolverManagerTest
 		assertEquals(0, store.get(result));
 	}
 
-	@Test
-	public void testTrivial()
-	{
-		assertLegalVariable("Limbs", "Global", FormatUtilities.NUMBER_MANAGER);
-		@SuppressWarnings("unchecked")
-		VariableID<Number> limbs = (VariableID<Number>) getVariableLibrary()
-			.getVariableID(getGlobalScopeInst(), "Limbs");
-		manager.solveChildren(limbs);
-	}
-
 	public class LimbManager implements FormatManager<Limb>
 	{
 

--- a/PCGen-Formula/code/src/test/pcgen/base/testsupport/TestUtilities.java
+++ b/PCGen-Formula/code/src/test/pcgen/base/testsupport/TestUtilities.java
@@ -21,7 +21,9 @@ import java.io.StringReader;
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 import junit.framework.TestCase;
 import pcgen.base.format.ArrayFormatManager;
@@ -145,6 +147,18 @@ public final class TestUtilities
 		map.put("STRING", "");
 		map.put("BOOLEAN", Boolean.FALSE);
 		return map::get;
+	}
+
+	public static class Container<T>
+	{
+		public List<T> objects = new ArrayList<>();
+		
+		public boolean set(T object)
+		{
+			objects.add(object);
+			return true;
+		}
+		
 	}
 
 }


### PR DESCRIPTION
Part of a process to break up the SolverManager objects to provide more flexibility and solve an underlying issue in the formula system regarding PC vs equipment vars.  Shares a common behavior between the existing *SolverManager objects.