### PR TITLE
[build] remove build scan plugin

### DIFF
--- a/PCGen-Formula/build.gradle
+++ b/PCGen-Formula/build.gradle
@@ -9,7 +9,6 @@
  */
 
 plugins {
-    id 'com.gradle.build-scan' version '3.6.3'
     id "ca.coglinc2.javacc" version "3.0.0"
     id 'java'
     id 'eclipse'

--- a/PCGen-Formula/gradle/reporting.gradle
+++ b/PCGen-Formula/gradle/reporting.gradle
@@ -31,9 +31,4 @@ spotbugs {
 	toolVersion = "3.1.8"
 }
 
-buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service';
-        termsOfServiceAgree = 'yes'
-}
-
 task allReports { dependsOn = ['checkstyleMain', 'pmdMain', 'spotbugsMain'] }


### PR DESCRIPTION
In newer versions of gradle build-scan has been removed and replaced.
Remove it to make an upgrade easier.